### PR TITLE
build: add ability to build extension for ocis apps-loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 .idea
 
 /.pnpm-store/
+docker-compose.override.yml

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Run the following command to serve the oCIS and the extension servers:
 docker compose up
 ```
 
-Extension URL: [host.docker.internal:3000](https://host.docker.internal:300)
+Extension URL: [host.docker.internal:3000](https://host.docker.internal:3000)
 
 oCIS URL: [host.docker.internal:9200](https://host.docker.internal:9200)
 

--- a/README.md
+++ b/README.md
@@ -3,33 +3,42 @@
 A markdown presentation viewer for [ownCloud web](https://github.com/owncloud/web/) (the webUI of [oCIS](https://github.com/owncloud/ocis/)) using the [reveal.js](https://revealjs.com/) library.
 
 It allows users to:
+
 - create slide presentations directly from markdown files
 - share the slides using public links
 
 ## Demonstration
+
 - [Demonstation page](https://ocis.in-nepal.de/files/link/public/bdSEsErbfGKoOIt?fileId=bdSEsErbfGKoOIt&files-public-link-view-mode=resource-table)
 - Click on `Open in Text Editor` to view the markdown content.
 - Click on `Open in Presentation Viewer` to view the rendered presentation.
 
 ## Prerequisites
+
+- [oCIS](https://github.com/owncloud/ocis) (>= 5.0.0)
 - [Node.js](https://nodejs.org/en/) (v18.17.1)
 - [pnpm](https://pnpm.io/) (v8.15.1)
 - [Docker](https://www.docker.com/)(optional)
 - [Docker Compose](https://docs.docker.com/compose/)(optional)
 
 ## Installation
+
 ### 1. Install Dependencies
+
 ```bash
 pnpm install
 ```
 
 ### 2. Build the extension
+
 ```bash
 pnpm build
 ```
+
 The extension will be built in the `dist` directory.
 
 ### 3. Serve the extension
+
 1. serve the content of the `dist` folder using any HTTP web-server
 2. configure web
    1. If you already have a dedicated `web.config.json` file, add an `external_apps` section (or edit the existing one). It has to have an item with `"id": "presentation-viewer"` and a `path` pointing to `web-app-presentation-viewer.js` e.g.:
@@ -51,22 +60,51 @@ The extension will be built in the `dist` directory.
 
 ## Development
 
-### 1. Install Dependencies
+Install dependencies:
+
 ```bash
 pnpm install
 ```
 
-### 2. Build the extension
+Build the extension. For development, build with watch.
 
-For development, build with watch
 ```bash
 pnpm build:w
 ```
-The extension will be served at [http://localhost:8082/web-app-presentation-viewer.js](http://localhost:8082/web-app-presentation-viewer.js)
 
-### 3. Start oCIS and the extension
+Depending on the oCIS version, we have two ways to load the apps into the oCIS server.
+
+### 1. Separate Extension Server (oCIS 5.0.0)
+
+With oCIS 5.0.0, it is only possible to load the external apps using the config file and app server.
+
+Run the following command to serve the oCIS and the extension servers:
+
 ```bash
 docker compose up
 ```
 
-The webUI of oCIS can be accessed at [https://host.docker.internal:9200](https://host.docker.internal:9200)
+Extension URL: [host.docker.internal:3000](https://host.docker.internal:300)
+
+oCIS URL: [host.docker.internal:9200](https://host.docker.internal:9200)
+
+### 2. oCIS Apps Loading (oCIS >= 5.1)
+
+Starting from oCIS 5.1.0 (not released yet), external apps can be loaded into the oCIS without config file and separate app server. We just use `WEB_ASSET_APPS_PATH`, an oCIS environemnet variable, while running oCIS server to set the directory where all the external apps are located.
+
+Follow these steps:
+
+1. Build the extension with the following command:
+
+   ```bash
+   APPS_LOADING=true pnpm build:w
+   ```
+
+2. Copy `docker-compose.override.example.yml` to `docker-compose.override.yml`
+3. Run the oCIS server:
+
+   ```bash
+   docker compose up
+   ```
+
+   oCIS URL: [host.docker.internal:9200](https://host.docker.internal:9200)

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ oCIS URL: [host.docker.internal:9200](https://host.docker.internal:9200)
 
 ### 2. oCIS Apps Loading (oCIS >= 5.1)
 
-Starting from oCIS 5.1.0 (not released yet), external apps can be loaded into the oCIS without config file and separate app server. We just use `WEB_ASSET_APPS_PATH`, an oCIS environemnet variable, while running oCIS server to set the directory where all the external apps are located.
+Starting from oCIS 5.1.0 (not released yet), external apps can be loaded into the oCIS without config file and separate app server. We just use `WEB_ASSET_APPS_PATH`, an oCIS environment variable, while running oCIS server to set the directory where all the external apps are located.
 
 Follow these steps:
 

--- a/config/web.config.json.sample
+++ b/config/web.config.json.sample
@@ -48,7 +48,7 @@
     },
     {
       "id": "presentation-viewer",
-      "path": "https://<url-where-the-dist-folder-is-served>/web-app-presentation-viewer.js"
+      "path": "https://<url-where-the-dist-folder-is-served>/com.github.jankaritech.web.mdpresentation/extension.js"
     }
   ]
 }

--- a/dev/docker/nginx.conf
+++ b/dev/docker/nginx.conf
@@ -1,0 +1,11 @@
+server {
+  listen 80;
+  server_name localhost;
+  
+  location / {
+    add_header 'Access-Control-Allow-Origin' '*';
+  }
+  root /usr/share/nginx/html;
+  index index.html index.htm;
+  try_files $uri $uri/ /index.html;
+}

--- a/dev/docker/web.config.json
+++ b/dev/docker/web.config.json
@@ -48,7 +48,7 @@
     },
     {
       "id": "presentation-viewer",
-      "path": "http://localhost:8082/web-app-presentation-viewer.js"
+      "path": "https://host.docker.internal:3000/com.github.jankaritech.web.mdpresentation/extension.js"
     }
   ]
 }

--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -1,0 +1,12 @@
+services:
+  ocis:
+    image: owncloud/ocis:latest
+    environment:
+      WEB_UI_CONFIG_FILE: null
+      WEB_ASSET_APPS_PATH: /web/apps
+    volumes:
+      - ./dist:/web/apps:ro
+
+  extension:
+    profiles:
+      - skip

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,9 +14,11 @@ services:
 
       # WEB
       WEB_UI_CONFIG_FILE: /web/config.json
+      WEB_APPS_PATH: /web/apps
 
       # IDM
       IDM_CREATE_DEMO_USERS: '${DEMO_USERS:-true}'
       IDM_ADMIN_PASSWORD: '${ADMIN_PASSWORD:-admin}'
     volumes:
       - ./dev/docker/web.config.json:/web/config.json:ro
+      - ./dist:/web/apps:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
 
       # WEB
       WEB_UI_CONFIG_FILE: /web/config.json
-      WEB_APPS_PATH: /web/apps
+      WEB_ASSET_APPS_PATH: /web/apps
 
       # IDM
       IDM_CREATE_DEMO_USERS: '${DEMO_USERS:-true}'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,24 +1,69 @@
 services:
   ocis:
-    image: ${OCIS_IMAGE:-owncloud/ocis:latest}
-    container_name: web_ocis
+    image: ${OCIS_IMAGE:-owncloud/ocis:5.0.0}
     entrypoint: /bin/sh
     command: ['-c', 'ocis init || true && ocis server']
-    ports:
-      - 9200:9200
     environment:
       # OCIS
       OCIS_URL: https://host.docker.internal:9200
-      OCIS_INSECURE: '${OCIS_INSECURE:-true}'
-      OCIS_LOG_LEVEL: '${OCIS_LOG_LEVEL:-error}'
-
+      OCIS_INSECURE: true
+      OCIS_LOG_LEVEL: error
       # WEB
       WEB_UI_CONFIG_FILE: /web/config.json
-      WEB_ASSET_APPS_PATH: /web/apps
-
       # IDM
-      IDM_CREATE_DEMO_USERS: '${DEMO_USERS:-true}'
-      IDM_ADMIN_PASSWORD: '${ADMIN_PASSWORD:-admin}'
+      IDM_CREATE_DEMO_USERS: ${DEMO_USERS:-true}
+      IDM_ADMIN_PASSWORD: admin
+      # PROXY
+      PROXY_ENABLE_BASIC_AUTH: true
+      PROXY_TLS: false
     volumes:
       - ./dev/docker/web.config.json:/web/config.json:ro
-      - ./dist:/web/apps:ro
+    extra_hosts:
+      - host.docker.internal:host-gateway
+    labels:
+      traefik.enable: true
+      traefik.http.routers.ocis.tls: true
+      traefik.http.routers.ocis.rule: PathPrefix(`/`)
+      traefik.http.routers.ocis.entrypoints: ocis
+      traefik.http.services.ocis.loadbalancer.server.port: 9200
+    depends_on:
+      - traefik
+
+  extension:
+    image: nginx:1.25.3
+    volumes:
+      - ./dev/docker/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./dist:/usr/share/nginx/html:ro
+    labels:
+      traefik.enable: true
+      traefik.http.routers.extension.tls: true
+      traefik.http.routers.extension.rule: PathPrefix(`/`)
+      traefik.http.routers.extension.entrypoints: extension
+      traefik.http.services.extension.loadbalancer.server.port: 80
+    depends_on:
+      - traefik
+
+  traefik:
+    image: traefik:2.11.0
+    restart: unless-stopped
+    command:
+      [
+        '--log.level=ERROR',
+        '--api.insecure=true',
+        '--api.dashboard=true',
+        '--pilot.dashboard=false',
+        '--providers.docker=true',
+        '--entrypoints.ocis.address=:9200',
+        '--entrypoints.extension.address=:3000',
+        '--providers.docker.exposedbydefault=false',
+        '--entrypoints.websecure.http.tls.options=default'
+      ]
+    labels:
+      traefik.enable: true
+      traefik.http.routers.traefik.rule: HostRegexp(`{any:.+}`)
+    ports:
+      - 8080:8080 # traefik dashboard
+      - 9200:9200 # ocis
+      - 3000:3000 # extension
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@babel/eslint-parser": "^7.23.10",
     "@ownclouders/extension-sdk": "0.0.5-alpha.2",
     "@ownclouders/prettier-config": "0.0.1",
+    "@types/node": "^20.11.30",
     "@typescript-eslint/eslint-plugin": "^7.1.1",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ devDependencies:
   '@ownclouders/prettier-config':
     specifier: 0.0.1
     version: 0.0.1
+  '@types/node':
+    specifier: ^20.11.30
+    version: 20.11.30
   '@typescript-eslint/eslint-plugin':
     specifier: ^7.1.1
     version: 7.1.1(@typescript-eslint/parser@7.1.1)(eslint@8.57.0)(typescript@5.3.3)
@@ -51,7 +54,7 @@ devDependencies:
     version: 5.3.3
   vite:
     specifier: ^5.0.12
-    version: 5.1.3(sass@1.71.0)
+    version: 5.1.3(@types/node@20.11.30)(sass@1.71.0)
   vue:
     specifier: ^3.4.16
     version: 3.4.19(typescript@5.3.3)
@@ -634,7 +637,7 @@ packages:
       rollup-plugin-node-polyfills: 0.2.1
       rollup-plugin-serve: 2.0.3
       sass: 1.71.0
-      vite: 5.1.3(sass@1.71.0)
+      vite: 5.1.3(@types/node@20.11.30)(sass@1.71.0)
     transitivePeerDependencies:
       - vue
     dev: true
@@ -858,6 +861,12 @@ packages:
     dependencies:
       undici-types: 5.26.5
     dev: false
+
+  /@types/node@20.11.30:
+    resolution: {integrity: sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==}
+    dependencies:
+      undici-types: 5.26.5
+    dev: true
 
   /@types/parse-json@4.0.2:
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
@@ -1113,7 +1122,7 @@ packages:
       vite: ^4.0.0 || ^5.0.0
       vue: ^3.2.25
     dependencies:
-      vite: 5.1.3(sass@1.71.0)
+      vite: 5.1.3(@types/node@20.11.30)(sass@1.71.0)
       vue: 3.4.19(typescript@5.3.3)
     dev: true
 
@@ -2818,7 +2827,6 @@ packages:
 
   /undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-    dev: false
 
   /update-browserslist-db@1.0.13(browserslist@4.23.0):
     resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}
@@ -2853,7 +2861,7 @@ packages:
     hasBin: true
     dev: false
 
-  /vite@5.1.3(sass@1.71.0):
+  /vite@5.1.3(@types/node@20.11.30)(sass@1.71.0):
     resolution: {integrity: sha512-UfmUD36DKkqhi/F75RrxvPpry+9+tTkrXfMNZD+SboZqBCMsxKtO52XeGzzuh7ioz+Eo/SYDBbdb0Z7vgcDJew==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -2881,6 +2889,7 @@ packages:
       terser:
         optional: true
     dependencies:
+      '@types/node': 20.11.30
       esbuild: 0.19.12
       postcss: 8.4.35
       rollup: 4.12.0

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,5 @@
+{
+  "id": "com.github.jankaritech.web.mdpresentation",
+  "entrypoint": "extension.js",
+  "config": {}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,9 @@
 import { AppWrapperRoute, defineWebApplication } from '@ownclouders/web-pkg'
 import App from './App.vue'
+import { id as appId } from '../public/manifest.json'
 
 export default defineWebApplication({
   setup() {
-    const appId = 'presentation-viewer'
-
     const appInfo = {
       name: 'Presentation Viewer',
       id: appId,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from '@ownclouders/extension-sdk'
 import { id } from './public/manifest.json'
 
-// TODO: make APPS_LOADING default when supporting ocis is released
+// TODO: make APPS_LOADING default after oCIS 5.1 is released
 const base =
   process.env.APPS_LOADING === 'true' ? '/assets/apps' : 'https://host.docker.internal:3000'
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,14 +1,13 @@
 import { defineConfig } from '@ownclouders/extension-sdk'
+import { id } from './public/manifest.json'
 
 export default defineConfig({
-  name: 'web-app-presentation-viewer',
-  server: {
-    port: 8082
-  },
+  base: '/vendor/apps/com.github.jankaritech.web.mdpresentation/',
   build: {
     rollupOptions: {
       output: {
-        entryFileNames: `[name].js`
+        dir: `dist/${id}`,
+        entryFileNames: `extension.js`
       }
     }
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,17 @@
 import { defineConfig } from '@ownclouders/extension-sdk'
 import { id } from './public/manifest.json'
 
+// TODO: make APPS_LOADING default when supporting ocis is released
+const base =
+  process.env.APPS_LOADING === 'true' ? '/assets/apps' : 'https://host.docker.internal:3000'
+
 export default defineConfig({
-  base: '/vendor/apps/com.github.jankaritech.web.mdpresentation/',
+  base: `${base}/${id}/`,
   build: {
     rollupOptions: {
       output: {
         dir: `dist/${id}`,
-        entryFileNames: `extension.js`
+        entryFileNames: 'extension.js'
       }
     }
   }


### PR DESCRIPTION
Added the option to build the extension for apps loading feature supported by ocis.

Now, to build the extension, we have a new `APPS_LOADING` env variable to switch between the build types.
1. `pnpm build` (Default) - build for extension server
2. `APPS_LOADING=true pnpm build` - extension can be loaded by oCIS using `WEB_ASSET_APPS_PATH`

Needs: https://github.com/owncloud/ocis/pull/8523

Fixes #31, fixes #30, fixes #45