### PR TITLE
feat: use ocis images from same directory level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Use ocis images from same directory level (https://github.com/JankariTech/web-app-presentation-viewer/pull/48)
+
 ### Fixed
 
 ### Changed

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,7 +5,7 @@
     :class="{ 'dark-mode': isDarkMode }"
   >
     <div class="reveal">
-      <div class="slides">
+      <div ref="slideContainer" class="slides">
         <section
           :data-markdown="url"
           :data-separator="dataSeparator"
@@ -17,10 +17,13 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref, watch } from 'vue'
-
-import { useThemeStore } from '@ownclouders/web-pkg'
-
+import { onMounted, ref, unref, watch } from 'vue'
+import {
+  useThemeStore,
+  useAppDefaults,
+  useAppFileHandling,
+  useClientService
+} from '@ownclouders/web-pkg'
 import Reveal from 'reveal.js'
 import RevealMarkdown from 'reveal.js/plugin/markdown/markdown'
 import RevealHighlight from 'reveal.js/plugin/highlight/highlight'
@@ -29,10 +32,23 @@ import 'reveal.js/dist/reveal.css'
 import 'reveal.js/plugin/highlight/monokai.css'
 import 'reveal.js/dist/theme/white.css'
 
+import { id as appId } from '../public/manifest.json'
+
+const themeStore = useThemeStore()
+const { loadFolderForFileContext, currentFileContext, activeFiles } = useAppDefaults({
+  applicationId: appId
+})
+const { getUrlForResource, revokeUrl } = useAppFileHandling({
+  clientService: useClientService
+})
+
+const isDarkMode = ref(themeStore.currentTheme.isDark)
+const slideContainer = ref<HTMLElement | undefined>()
+
 const dataSeparator = '\r?\n---\r?\n'
 const dataSeparatorVertical = '\r?\n--\r?\n'
-const themeStore = useThemeStore()
-const isDarkMode = ref(themeStore.currentTheme.isDark)
+const images = {}
+
 let reveal: Reveal.Api
 
 defineProps({
@@ -49,7 +65,10 @@ watch(
   }
 )
 
-onMounted(() => {
+onMounted(async () => {
+  await loadFolderForFileContext(unref(currentFileContext))
+  await parseImagesUrl()
+
   reveal = new Reveal({
     plugins: [RevealMarkdown, RevealHighlight]
   })
@@ -61,7 +80,34 @@ onMounted(() => {
     center: true,
     controlsLayout: 'edges'
   })
+
+  reveal.on('ready', () => {
+    const imgElements = unref(slideContainer).getElementsByTagName('img')
+    updateImageUrls(imgElements)
+  })
 })
+
+// METHODS
+function updateImageUrls(imgElements: HTMLCollectionOf<HTMLImageElement>) {
+  for (const el of imgElements) {
+    const src = el.src.split('/').pop()
+    el.src = images[src]
+  }
+}
+async function parseImagesUrl() {
+  for (const file of unref(activeFiles)) {
+    // TODO: use image mimetypes
+    if (file.extension === 'png') {
+      const url = await getUrlForResource(unref(currentFileContext).space, file)
+      images[file.name] = await getBlobUrl(url)
+    }
+  }
+}
+async function getBlobUrl(url: string) {
+  const data = await fetch(url).then(async (res) => await res.blob())
+  const blob = new Blob([data], { type: data.type })
+  return URL.createObjectURL(blob)
+}
 </script>
 
 <style lang="scss">

--- a/src/App.vue
+++ b/src/App.vue
@@ -17,7 +17,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, unref, watch } from 'vue'
+import { computed, onMounted, onBeforeUnmount, ref, unref, watch } from 'vue'
 import {
   useThemeStore,
   useAppDefaults,
@@ -69,6 +69,7 @@ watch(
   }
 )
 
+// LIFECYCLE HOOKS
 onMounted(async () => {
   await loadFolderForFileContext(unref(currentFileContext))
   await parseImagesUrl()
@@ -88,6 +89,11 @@ onMounted(async () => {
   reveal.on('ready', () => {
     const imgElements = unref(slideContainer).getElementsByTagName('img')
     updateImageUrls(imgElements)
+  })
+})
+onBeforeUnmount(() => {
+  Object.values(unref(imageUrls)).forEach((url) => {
+    revokeUrl(url)
   })
 })
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -43,7 +43,7 @@ const { loadFolderForFileContext, currentFileContext, activeFiles } = useAppDefa
   applicationId: appId
 })
 const { getUrlForResource, revokeUrl } = useAppFileHandling({
-  clientService: useClientService
+  clientService: useClientService()
 })
 const appsStore = useAppsStore()
 const { serverUrl } = useConfigStore()

--- a/src/App.vue
+++ b/src/App.vue
@@ -142,6 +142,7 @@ async function parseImageUrl(name: string) {
     if (file.name === name) {
       const url = await getUrlForResource(unref(currentFileContext).space, file)
       // reload the active files
+      // TODO: implement caching
       await loadFolderForFileContext(unref(currentFileContext))
       return getBlobUrl(url)
     }

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,7 +5,7 @@
     :class="{ 'dark-mode': isDarkMode }"
   >
     <div class="reveal">
-      <div ref="slideContainer" class="slides">
+      <div ref="slideContainer" id="slideContainer" class="slides">
         <section
           :data-markdown="url"
           :data-separator="dataSeparator"
@@ -166,6 +166,33 @@ async function getBlobUrl(url: string) {
     h5,
     h6 {
       color: var(--oc-color-text-default) !important;
+    }
+  }
+}
+
+#slideContainer {
+  section {
+    display: flex !important;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+
+    > * {
+      margin-top: 0;
+    }
+
+    p:has(img) {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      overflow: hidden;
+
+      img {
+        width: auto;
+        height: auto;
+      }
     }
   }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -17,13 +17,15 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref, unref, watch } from 'vue'
+import { computed, onMounted, ref, unref, watch } from 'vue'
 import {
   useThemeStore,
   useAppDefaults,
   useAppFileHandling,
-  useClientService
+  useClientService,
+  useAppsStore
 } from '@ownclouders/web-pkg'
+import { Resource } from '@ownclouders/web-client/src'
 import Reveal from 'reveal.js'
 import RevealMarkdown from 'reveal.js/plugin/markdown/markdown'
 import RevealHighlight from 'reveal.js/plugin/highlight/highlight'
@@ -32,6 +34,7 @@ import 'reveal.js/dist/reveal.css'
 import 'reveal.js/plugin/highlight/monokai.css'
 import 'reveal.js/dist/theme/white.css'
 
+import { getMediaMimeTypes } from './helpers/mediaMimeTypes'
 import { id as appId } from '../public/manifest.json'
 
 const themeStore = useThemeStore()
@@ -41,13 +44,14 @@ const { loadFolderForFileContext, currentFileContext, activeFiles } = useAppDefa
 const { getUrlForResource, revokeUrl } = useAppFileHandling({
   clientService: useClientService
 })
+const appsStore = useAppsStore()
 
 const isDarkMode = ref(themeStore.currentTheme.isDark)
 const slideContainer = ref<HTMLElement | undefined>()
+const imageUrls = ref()
 
 const dataSeparator = '\r?\n---\r?\n'
 const dataSeparatorVertical = '\r?\n--\r?\n'
-const images = {}
 
 let reveal: Reveal.Api
 
@@ -87,21 +91,38 @@ onMounted(async () => {
   })
 })
 
+// COMPUTED
+const mediaMimeTypes = computed(() =>
+  getMediaMimeTypes(appsStore.externalAppConfig['preview']?.mimeTypes)
+)
+const mediaFiles = computed<Resource[]>(() => {
+  if (!unref(activeFiles)) {
+    return []
+  }
+
+  return unref(activeFiles).filter((file: Resource) => {
+    return unref(mediaMimeTypes).includes(file.mimeType?.toLowerCase())
+  })
+})
+
 // METHODS
 function updateImageUrls(imgElements: HTMLCollectionOf<HTMLImageElement>) {
+  const imgUrls = unref(imageUrls)
   for (const el of imgElements) {
     const src = el.src.split('/').pop()
-    el.src = images[src]
+    el.src = imgUrls[src]
   }
 }
 async function parseImagesUrl() {
-  for (const file of unref(activeFiles)) {
+  const images = {}
+  for (const file of unref(mediaFiles)) {
     // TODO: use image mimetypes
     if (file.extension === 'png') {
       const url = await getUrlForResource(unref(currentFileContext).space, file)
       images[file.name] = await getBlobUrl(url)
     }
   }
+  imageUrls.value = images
 }
 async function getBlobUrl(url: string) {
   const data = await fetch(url).then(async (res) => await res.blob())

--- a/src/helpers/mediaMimeTypes.ts
+++ b/src/helpers/mediaMimeTypes.ts
@@ -1,0 +1,16 @@
+export const getMediaMimeTypes = (extensionMimeTypes: string[] = []) => {
+  return [
+    'audio/flac',
+    'audio/mpeg',
+    'audio/ogg',
+    'audio/wav',
+    'audio/x-flac',
+    'audio/x-wav',
+    'image/gif',
+    'image/jpeg',
+    'image/png',
+    'video/mp4',
+    'video/webm',
+    ...extensionMimeTypes
+  ]
+}


### PR DESCRIPTION
## Description
FEAT: able to use images available at the same directory level as the markdown file in the ocis server.

Requirements:

>1. allow to embed images that are stored in the same folder or its subfolders by using the markdown image syntax

same folder - :heavy_check_mark:
subfolders - :x: (Follow up in next PR)

>2. not allowing to embed files from a folder of higher levels

:heavy_check_mark: 

>3. require the whole folder be publicly shared if the public viewer should see the images

:heavy_check_mark: 

>4. if only the markdown file is publicly share the viewer should not be able to access the images

:heavy_check_mark: 

### Test Cases:
- local images (image from current directory level)
- large local images
- multiple small images (if images are large then only one might be visible)
- uploaded image (upload into markdown)
- external image url
- audio/video (doesn't work - not supported by the md parser)

## Related Issue
- Part of #27

## Screenshots (if appropriate):
`Owner`:
![Screenshot from 2024-04-15 12-11-10](https://github.com/JankariTech/web-app-presentation-viewer/assets/52366632/7999491f-b711-4c79-9ced-1c5f5600d31f) | ![Screenshot from 2024-04-15 12-11-04](https://github.com/JankariTech/web-app-presentation-viewer/assets/52366632/05ce7f74-6ac2-4093-a326-df731f6a30a8)
--|--

`Folder Link - Viewer`:
![Screenshot from 2024-04-15 12-13-44](https://github.com/JankariTech/web-app-presentation-viewer/assets/52366632/2ab70c1c-0c2c-45b3-8853-f6f3a5cc631b) | ![Screenshot from 2024-04-15 12-13-52](https://github.com/JankariTech/web-app-presentation-viewer/assets/52366632/b290a8bf-62cd-49f7-a1ac-2e16295c9103)
--|--

`MD File link -  Editor`:
![Screenshot from 2024-04-15 12-18-28](https://github.com/JankariTech/web-app-presentation-viewer/assets/52366632/0e1abe17-aa26-4eaf-b383-52966d45b90e) | ![Screenshot from 2024-04-15 12-12-26](https://github.com/JankariTech/web-app-presentation-viewer/assets/52366632/3b1edc8d-848c-4fd7-9044-4cc42a67d696)
--|--


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)
- [ ] Documentation only (no source changes)
- [ ] Maintenance (e.g. dependency updates or tooling)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation updated