### PR TITLE
feat: load images from sub-folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Use ocis images from same directory level (https://github.com/JankariTech/web-app-presentation-viewer/pull/48)
+- Load ocis images from the sub directory level (https://github.com/JankariTech/web-app-presentation-viewer/pull/60)
 
 ### Fixed
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -140,10 +140,7 @@ async function updateImageUrls(localImgElements: HTMLImageElement[]) {
   for (const el of localImgElements) {
     // trim 'mediaBasePath'
     // remove leading '.' and '/'
-    const srcPath = el.src
-      .replace(mediaBasePath, '')
-      .replace(/$(\.|\/)/, '')
-      .replace(/$(\.|\/)/, '')
+    const srcPath = el.src.replace(mediaBasePath, '').replace(/$\.\//, '').replace(/$\//, '')
 
     const blobUrl = await parseImageUrl(srcPath)
     if (blobUrl) {


### PR DESCRIPTION
## Description
Implement loading ocis images from the sub-directories.

## Related Issue
- Resolves https://github.com/JankariTech/web-app-presentation-viewer/issues/27

## Motivation and Context

## How Has This Been Tested?
- test environment: :hand: and :robot: 

## Screenshots (if appropriate):
![image](https://github.com/JankariTech/web-app-presentation-viewer/assets/52366632/4befa4c6-36b0-49fc-8f9e-e2538ec4267f)

```md
## Slide With oCIS Image - sub

![webdriver_ill.jpg](./sub/inner/webdriver_ill.jpg)
```
![image](https://github.com/JankariTech/web-app-presentation-viewer/assets/52366632/5cdae1f5-0769-4a27-9362-e0458838afe9)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)
- [ ] Documentation only (no source changes)
- [ ] Maintenance (e.g. dependency updates or tooling)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation updated