### PR TITLE
refactor: update ocis images directly in markdown content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Use ocis images from same directory level (https://github.com/JankariTech/web-app-presentation-viewer/pull/48)
+- Loading spinner until presentation is ready (https://github.com/JankariTech/web-app-presentation-viewer/pull/61)
 - Load ocis images from the sub directory level (https://github.com/JankariTech/web-app-presentation-viewer/pull/60)
+- Use ocis images from same directory level (https://github.com/JankariTech/web-app-presentation-viewer/pull/48)
 
 ### Fixed
 
 ### Changed
+
+- Parse and update local image urls directly in the markdown content (https://github.com/JankariTech/web-app-presentation-viewer/pull/61)
 
 ### Removed
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -59,6 +59,7 @@ const isReadyToShow = ref<boolean>(false)
 
 const dataSeparator = '\r?\n---\r?\n'
 const dataSeparatorVertical = '\r?\n--\r?\n'
+const mdImageRegex = /!\[.*\]\((?!(?:http|data))(.*)\)/g
 
 let reveal: Reveal.Api
 
@@ -80,13 +81,14 @@ watch(
 onMounted(async () => {
   await loadFolderForFileContext(unref(currentFileContext))
 
+  // fetch the markdown file
+  // build the local image urls
   await fetch(unref(url))
     .then((res) => res.text())
     .then(async (data) => {
       const parsedData = []
       for (let line of data.split('\n')) {
-        const imgRegex = /!\[.*\]\((?!(?:http|blob))(.*)\)/g
-        const matches = data.matchAll(imgRegex)
+        const matches = line.matchAll(mdImageRegex)
         for (const match of matches) {
           const imgPath = match[1]
           const imageUrl = await updateImageUrls(imgPath)

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,9 +1,10 @@
 <template>
   <div
     id="presentation-viewer-main"
-    class="presentation-viewer oc-flex"
+    class="presentation-viewer"
     :class="{ 'dark-mode': isDarkMode }"
   >
+    <AppLoadingSpinner v-if="!isReadyToShow" />
     <div ref="revealContainer" class="reveal">
       <div id="slideContainer" ref="slideContainer" class="slides">
         <section
@@ -21,6 +22,7 @@
 <script setup lang="ts">
 import { computed, onMounted, onBeforeUnmount, ref, unref, watch } from 'vue'
 import {
+  AppLoadingSpinner,
   useThemeStore,
   useAppDefaults,
   useAppFileHandling,
@@ -53,6 +55,7 @@ const slideContainer = ref<HTMLElement>()
 const revealContainer = ref<HTMLElement>()
 const mdTextarea = ref<HTMLElement>()
 const mediaUrls = ref<string[]>([])
+const isReadyToShow = ref<boolean>(false)
 
 const dataSeparator = '\r?\n---\r?\n'
 const dataSeparatorVertical = '\r?\n--\r?\n'
@@ -105,6 +108,8 @@ onMounted(async () => {
     center: true,
     controlsLayout: 'edges'
   })
+
+  isReadyToShow.value = true
 })
 onBeforeUnmount(() => {
   unref(mediaUrls).forEach((url) => {

--- a/src/App.vue
+++ b/src/App.vue
@@ -138,8 +138,7 @@ const mediaFiles = computed<Resource[]>(() => {
 
 // METHODS
 async function updateImageUrls(localImagePath: string) {
-  // trim 'mediaBasePath'
-  // remove leading '.' and '/'
+  // remove leading './' or '/'
   const srcPath = localImagePath.replace(/^\.\//, '').replace(/^\//, '')
 
   const blobUrl = await parseImageUrl(srcPath)


### PR DESCRIPTION
## Description
Parsing the ocis images and updating the urls directly in the markdown content and let reveal prepare the slides afterward.
Also added loading spinner until the presentation is ready to show.


## How Has This Been Tested?
- test environment: :computer: :raised_back_of_hand:

## Screenshots (if appropriate):
![Screenshot from 2024-07-15 16-28-04](https://github.com/user-attachments/assets/d1a143e7-4f93-431b-9760-79203a96e707) | ![Screenshot from 2024-07-15 16-27-35](https://github.com/user-attachments/assets/b034d405-11f4-44eb-b653-06496a873c4a)
--|--
![Screenshot from 2024-07-15 16-27-38](https://github.com/user-attachments/assets/daaa7521-fdd2-4974-b7c0-34a3b0494579) | ![Screenshot from 2024-07-15 16-27-41](https://github.com/user-attachments/assets/cda6bedf-c4b8-4e1f-b59f-72f456846e37)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)
- [ ] Documentation only (no source changes)
- [ ] Maintenance (e.g. dependency updates or tooling)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation updated