### PR TITLE
ci: upload production ready extension artifacts as the release assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: lint-build-e2e
+name: lint-and-tests
 
 on:
   push:
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: pnpm-install
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         with:
           run_install: |
             - args: [--frozen-lockfile, --strict-peer-dependencies]
@@ -27,6 +27,14 @@ jobs:
 
       - name: build
         run: pnpm build
+
+      - name: upload-dist
+        uses: actions/upload-artifact@v4
+        # if: github.event_name == 'release'
+        with:
+          name: dist
+          path: dist/
+          retention-days: 1
 
       - name: ocis-server
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,21 @@
 name: lint-and-tests
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:
       - main
   pull_request:
+  workflow_call:
 
 env:
   OCIS_URL: https://localhost:9200
 
 jobs:
-  ci:
+  lint-and-tests:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -30,7 +35,7 @@ jobs:
 
       - name: upload-dist
         uses: actions/upload-artifact@v4
-        # if: github.event_name == 'release'
+        if: github.event_name == 'release'
         with:
           name: dist
           path: dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,17 @@ jobs:
           name: dist
           path: dist/
 
-      - name: create-zip
-        run: echo mdpresentation-${{ github.ref_name }}.zip
-        # mkdir dist/release && (cd dist && zip -r - .) >dist/release/mdpresentation-${{ github.ref_name }}.zip
+      - name: create-artifacts
+        run: |
+          (cd dist && zip -r - .) >dist/mdpresentation-${{ github.ref_name }}.zip
+          mkdir -p dist/release
+          mv dist/mdpresentation-${{ github.ref_name }}.zip dist/release/
+          md5sum dist/release/mdpresentation-${{ github.ref_name }}.zip >dist/release/md5sum.txt
+          sha256sum dist/release/mdpresentation-${{ github.ref_name }}.zip >dist/release/sha256sum.txt
 
-      # - name: publish-artifacts
-      #   uses: fnkr/github-action-ghr@v1
-      #   env:
-      #     GHR_PATH: dist/release/
-      #     GHR_REPLACE: true
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: publish-artifacts
+        uses: fnkr/github-action-ghr@v1
+        env:
+          GHR_PATH: dist/release/
+          GHR_REPLACE: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,9 @@ jobs:
 
       - name: create-artifacts
         run: |
-          (cd dist && zip -r - .) >dist/mdpresentation-${{ github.ref_name }}.zip
+          (cd dist && zip -r - .) >mdpresentation-${{ github.ref_name }}.zip
           mkdir -p dist/release
-          mv dist/mdpresentation-${{ github.ref_name }}.zip dist/release/
+          mv mdpresentation-${{ github.ref_name }}.zip dist/release/
           md5sum dist/release/mdpresentation-${{ github.ref_name }}.zip >dist/release/md5sum.txt
           sha256sum dist/release/mdpresentation-${{ github.ref_name }}.zip >dist/release/sha256sum.txt
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,8 @@
 name: release
 
 on:
-  # release:
-  #   types: [published]
-  push:
-    branches:
-      - main
-  pull_request:
+  release:
+    types: [published]
 
 jobs:
   ci:
@@ -22,12 +18,13 @@ jobs:
           name: dist
           path: dist/
 
-      - run: ls -al
+      - name: create-zip
+        run: echo mdpresentation-${{ github.ref_name }}.zip
+        # mkdir dist/release && (cd dist && zip -r - .) >dist/release/mdpresentation-${{ github.ref_name }}.zip
 
-      - name: publish-artifacts
-        uses: fnkr/github-action-ghr@v1
-        env:
-          GHR_PATH: dist/
-          GHR_COMPRESS: zip
-          GHR_REPLACE: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: publish-artifacts
+      #   uses: fnkr/github-action-ghr@v1
+      #   env:
+      #     GHR_PATH: dist/release/
+      #     GHR_REPLACE: true
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: release
+
+on:
+  # release:
+  #   types: [published]
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+
+  publish-artifacts:
+    needs: [ci]
+    runs-on: ubuntu-latest
+    steps:
+      - name: download-dist
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - run: ls -al
+
+      - name: publish-artifacts
+        uses: fnkr/github-action-ghr@v1
+        env:
+          GHR_PATH: dist/
+          GHR_COMPRESS: zip
+          GHR_REPLACE: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
Whenever there's a release, upload the necessary artifacts to the release assets. These assets will be added:
- `mdpresentation-{release_tag}.zip`
- `md5sum.txt`
- `sha256sum.txt`


## Related Issue
- Fixes #63

## Screenshots (if appropriate):

![Screenshot from 2024-07-17 17-10-44](https://github.com/user-attachments/assets/c29708b9-89cd-4062-ae99-5bdb921f5f89)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)
- [ ] Documentation only (no source changes)
- [ ] Maintenance (e.g. dependency updates or tooling)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation updated