### PR TITLE
fix: use separate color and bg color for single code block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Single backtick is not recognizable as code block (https://github.com/JankariTech/web-app-presentation-viewer/pull/82)
 - Code blocks in lists are not using existing space (https://github.com/JankariTech/web-app-presentation-viewer/pull/80)
 
 ### Changed

--- a/src/App.vue
+++ b/src/App.vue
@@ -216,6 +216,18 @@ function basename(path: string) {
     h6 {
       color: var(--oc-color-text-default) !important;
     }
+
+    code {
+      background-color: var(--code-bg-color-dark) !important;
+    }
+
+    pre {
+      background-color: var(--pre-bg-color-dark) !important;
+
+      code {
+        background-color: inherit !important;
+      }
+    }
   }
 }
 
@@ -245,16 +257,29 @@ function basename(path: string) {
     }
 
     code {
-      color: var(--single-code-color);
-      background-color: var(--single-code-bg-color);
+      color: var(--code-color);
+      background-color: var(--code-bg-color);
       padding: 0px 4px;
       border-radius: 0.5rem;
+      font-size: 0.8em;
+      text-shadow: none;
     }
   }
 
   li pre {
     margin: 0;
     width: 100%;
+  }
+
+  pre {
+    background-color: var(--pre-bg-color);
+
+    code {
+      padding: 4px;
+      color: inherit;
+      font-size: inherit;
+      background-color: inherit;
+    }
   }
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -37,6 +37,7 @@ import RevealHighlight from 'reveal.js/plugin/highlight/highlight'
 import 'reveal.js/dist/reveal.css'
 import 'reveal.js/plugin/highlight/monokai.css'
 import 'reveal.js/dist/theme/white.css'
+import './css/variables.css'
 
 import { getMediaMimeTypes } from './helpers/mediaMimeTypes'
 import { id as appId } from '../public/manifest.json'
@@ -241,6 +242,13 @@ function basename(path: string) {
         width: auto;
         height: auto;
       }
+    }
+
+    code {
+      color: var(--single-code-color);
+      background-color: var(--single-code-bg-color);
+      padding: 0px 4px;
+      border-radius: 0.5rem;
     }
   }
 

--- a/src/css/variables.css
+++ b/src/css/variables.css
@@ -1,0 +1,5 @@
+/* color */
+:root {
+  --single-code-color: #c1798b;
+  --single-code-bg-color: #f9f2f4;
+}

--- a/src/css/variables.css
+++ b/src/css/variables.css
@@ -1,5 +1,8 @@
 /* color */
 :root {
-  --single-code-color: #c1798b;
-  --single-code-bg-color: #f9f2f4;
+  --code-color: #c1798b;
+  --code-bg-color: #f9f2f4;
+  --code-bg-color-dark: #35262a;
+  --pre-bg-color: #f4f7f8;
+  --pre-bg-color-dark: #232428;
 }


### PR DESCRIPTION
## Description
single code block now has a separate color and background color (similar to web markdown editor)

![Screenshot from 2024-09-10 15-49-03](https://github.com/user-attachments/assets/7a748e31-f61e-4c29-9f5a-ebbc2d3072af) | ![Screenshot from 2024-09-10 15-49-07](https://github.com/user-attachments/assets/5a6a7793-fc04-49a1-b170-f528c753b20a)
--|--
![Screenshot from 2024-09-10 15-48-43](https://github.com/user-attachments/assets/9e94c434-32d9-404f-a7c0-6fcdc93efcb1) | ![Screenshot from 2024-09-10 15-48-50](https://github.com/user-attachments/assets/bd6ded42-4590-47b5-b004-fe941fe5852b)

## Related Issue
- Fixes #39

## How Has This Been Tested?
- test environment: :raised_back_of_hand: 

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)
- [ ] Documentation only (no source changes)
- [ ] Maintenance (e.g. dependency updates or tooling)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation updated