### PR TITLE
fix: trying to load an image from not existing folder, breaks the presentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Trying to load an image from an not existing folder, breaks the presentation (https://github.com/JankariTech/web-app-presentation-viewer/issues/86)
 - Single backtick is not recognizable as code block (https://github.com/JankariTech/web-app-presentation-viewer/pull/82)
 - Code blocks in lists are not using existing space (https://github.com/JankariTech/web-app-presentation-viewer/pull/80)
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -175,6 +175,11 @@ async function getSubMediaFile(path: string): Promise<Resource> {
   let currentFiles = unref(activeFiles)
   for (const parent of parents) {
     const file = findFile(parent, currentFiles)
+    // return if the parent folder is not found
+    if (!file) {
+      return
+    }
+
     const { children } = await webdav.listFiles(unref(currentFileContext).space, {
       path: file.path,
       fileId: file.fileId

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -76,6 +76,8 @@ Ordered list:
 ![non-existing](./non-existing-image.png)
 
 ![sub-folder-image](./sub/another-cool.jpg)
+
+![sub-folder-image](./non-existing/another-cool.jpg)
 ---
 
 ### Code block

--- a/tests/unit/__snapshots__/App.spec.ts.snap
+++ b/tests/unit/__snapshots__/App.spec.ts.snap
@@ -46,6 +46,7 @@ exports[`App component > render markdown slides 1`] = `
         <p><img src="blob:nodedata:0295bafb-5976-468a-a263-685a8872cb96" alt="cool"></p>
         <p><img src="./non-existing-image.png" alt="non-existing"></p>
         <p><img src="blob:nodedata:0295bafb-5976-468a-a263-685a8872cb96" alt="sub-folder-image"></p>
+        <p><img src="./non-existing/another-cool.jpg" alt="sub-folder-image"></p>
       </section>
       <section data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true" class="future">
         <h3 id="code-block">Code block</h3>


### PR DESCRIPTION
## Description
check if the sub-folder exists and return early if not

## Related Issue
- Fixes #86

## Motivation and Context

## How Has This Been Tested?
- test environment: :raised_back_of_hand: 

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)
- [ ] Documentation only (no source changes)
- [ ] Maintenance (e.g. dependency updates or tooling)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation updated