### PR TITLE
fix: .svg files cannot be used as images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- SVG files cannot be used as images (https://github.com/JankariTech/web-app-presentation-viewer/issues/85)
 - Trying to load an image from an not existing folder, breaks the presentation (https://github.com/JankariTech/web-app-presentation-viewer/issues/86)
 - Single backtick is not recognizable as code block (https://github.com/JankariTech/web-app-presentation-viewer/pull/82)
 - Code blocks in lists are not using existing space (https://github.com/JankariTech/web-app-presentation-viewer/pull/80)

--- a/src/helpers/mediaMimeTypes.ts
+++ b/src/helpers/mediaMimeTypes.ts
@@ -11,6 +11,7 @@ export const getMediaMimeTypes = (extensionMimeTypes: string[] = []) => {
     'image/png',
     'video/mp4',
     'video/webm',
+    'image/svg+xml',
     ...extensionMimeTypes
   ]
 }

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -7,6 +7,7 @@ vi.mock('@ownclouders/web-pkg', () => ({
     loadFolderForFileContext: vi.fn(),
     currentFileContext: {},
     activeFiles: [
+      { name: 'cool.svg', path: '/cool.svg', mimeType: 'image/svg+xml' },
       { name: 'cool.png', path: '/cool.png', mimeType: 'image/png' },
       { name: 'sub', path: '/sub' }
     ]
@@ -71,6 +72,8 @@ Ordered list:
 ---
 
 ### ocCIS Image
+![cool](./cool.svg)
+
 ![cool](./cool.png)
 
 ![non-existing](./non-existing-image.png)

--- a/tests/unit/__snapshots__/App.spec.ts.snap
+++ b/tests/unit/__snapshots__/App.spec.ts.snap
@@ -44,6 +44,7 @@ exports[`App component > render markdown slides 1`] = `
       <section data-markdown="" data-markdown-parsed="true" style="top: 350px; display: none;" hidden="" aria-hidden="true" class="future">
         <h3 id="occis-image">ocCIS Image</h3>
         <p><img src="blob:nodedata:0295bafb-5976-468a-a263-685a8872cb96" alt="cool"></p>
+        <p><img src="blob:nodedata:0295bafb-5976-468a-a263-685a8872cb96" alt="cool"></p>
         <p><img src="./non-existing-image.png" alt="non-existing"></p>
         <p><img src="blob:nodedata:0295bafb-5976-468a-a263-685a8872cb96" alt="sub-folder-image"></p>
         <p><img src="./non-existing/another-cool.jpg" alt="sub-folder-image"></p>


### PR DESCRIPTION
## Description
Add svg mimetype so that the image links are built for svg files as well

## Related Issue
- Fixes #85

## Motivation and Context

## How Has This Been Tested?
- test environment: :raised_back_of_hand: 

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)
- [ ] Documentation only (no source changes)
- [ ] Maintenance (e.g. dependency updates or tooling)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation updated