### PR TITLE
fix retry

### DIFF
--- a/cucumber.cjs
+++ b/cucumber.cjs
@@ -1,7 +1,7 @@
 module.exports = {
   default: {
     require: ['tests/e2e/**/*.js'],
-    retry: process.env.RETRY || 0,
+    retry: parseInt(process.env.RETRY, 10) || 0,
     format: ['@cucumber/pretty-formatter']
   }
 }


### PR DESCRIPTION
## Description

playwright expects `retry` to be integer and complains if its not. Passing it in as a env. variable makes it be a string

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Tests only (no source changes)
- [ ] Documentation only (no source changes)
- [ ] Maintenance (e.g. dependency updates or tooling)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation updated