### PR TITLE
allow to show browser console output in tests

### DIFF
--- a/tests/e2e/config.js
+++ b/tests/e2e/config.js
@@ -8,7 +8,8 @@ const config = {
   slowMo: parseInt(process.env.SLOW_MO) || 0,
   timeout: parseInt(process.env.TIMEOUT) || 60,
   minTimeout: parseInt(process.env.MIN_TIMEOUT) || 5,
-  headless: process.env.HEADLESS === 'true'
+  headless: process.env.HEADLESS === 'true',
+  debug: process.env.DEBUG === 'true'
 }
 
 module.exports = config

--- a/tests/e2e/hooks.js
+++ b/tests/e2e/hooks.js
@@ -23,6 +23,9 @@ AfterAll(async function () {
 Before(async function () {
   global.context = await global.browser.newContext({ ignoreHTTPSErrors: true })
   global.page = await global.context.newPage()
+  if (config.debug) {
+    global.page.on('console', (msg) => console.log(msg.text()))
+  }
 })
 
 // Cleanup after each scenario


### PR DESCRIPTION
## Description

I had a hard time debugging some CI issues, till I finally showed the output of the browser console.
This allows to set the env. variable `DEBUG` to `true` and then the browser console output will be shown in the test run.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Tests only (no source changes)
- [ ] Documentation only (no source changes)
- [ ] Maintenance (e.g. dependency updates or tooling)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation updated