### PR TITLE
Test: check content of currently open slide

### DIFF
--- a/tests/e2e/features/presentationViewer.feature
+++ b/tests/e2e/features/presentationViewer.feature
@@ -2,7 +2,7 @@ Feature: markdown presentation viewer
   As a user
   I want to view markdown documents in presentation format
   So that I can easily present content in a structured manner
-  
+
   Background:
     Given user "admin" has uploaded the markdown file "test-markdown.md" using API
     And user "admin" has logged in
@@ -11,3 +11,8 @@ Feature: markdown presentation viewer
   Scenario: preview markdown file in presentation viewer
     When user "admin" previews a markdown file "test-markdown.md" in presentation viewer
     Then markdown file "test-markdown.md" should be opened in the presentation viewer
+
+
+  Scenario: check content of a slide
+    When user "admin" previews a markdown file "test-markdown.md" in presentation viewer
+    Then the content of the current slide should be "PRESENTATION VIEWER"

--- a/tests/e2e/pageObjects/PresentationViewerPage.js
+++ b/tests/e2e/pageObjects/PresentationViewerPage.js
@@ -2,6 +2,11 @@ class PresentationViewer {
   constructor() {
     this.slidesContainerSelector = '#presentation-viewer-main .slides'
     this.presentationViewerHomepageSelector = '#presentation-viewer-main'
+    this.currentSlideSelector = '#presentation-viewer-main section.present'
+  }
+
+  async getCurrentSlideContent() {
+    return await page.locator(this.currentSlideSelector).innerText()
   }
 }
 

--- a/tests/e2e/stepDefinitions/presentationViewerContext.js
+++ b/tests/e2e/stepDefinitions/presentationViewerContext.js
@@ -39,3 +39,9 @@ Then(
     await expect(page.locator(presentationViewer.slidesContainerSelector)).toBeVisible()
   }
 )
+
+Then('the content of the current slide should be {string}', async function (content) {
+  await expect(page.locator(presentationViewer.currentSlideSelector)).toBeVisible()
+  const currentSlideContent = await presentationViewer.getCurrentSlideContent()
+  await expect(currentSlideContent).toBe(content)
+})


### PR DESCRIPTION
<!--
Thanks for submitting a change to web app presentation viewer!

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the main branch which holds the next version of web app presentation viewer.

Please set the following labels:

- Assignment: assign to self
- Reviewers: pick at least one
- Labels: pick at least one
- Project: Web App Presentation Viewer (JankariTech)
-->

## Description
This PR checks the content of the slide which appears when a user opens `.md` file in `presentation viewer` using the scenario:
`Scenario: check content of a slide`

Whenever an user opens the `md` file in `presentation viewer`, locator `currentSlideSelector` selects the first slide (current open slide). We then get that slide's content using `getCurrentSlideContent` and finally assert that content with the expected one using `await expect(getCurrentSlideContent).toBe(content)`

## Related Issue
- Part of https://github.com/JankariTech/web-app-presentation-viewer/issues/16

## Motivation and Context

## How Has This Been Tested?
- test environment:
Locally and CI

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Tests only (no source changes)
- [ ] Documentation only (no source changes)
- [ ] Maintenance (e.g. dependency updates or tooling)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation updated