### PR TITLE
[tests-only] update context menu button selector

### DIFF
--- a/tests/e2e/pageObjects/FilesPage.js
+++ b/tests/e2e/pageObjects/FilesPage.js
@@ -3,7 +3,7 @@ const config = require('../config')
 
 class Files {
   constructor() {
-    this.contextMenuBtnSelector = '.resource-table-btn-action-dropdown'
+    this.contextMenuBtnSelector = '[class*=-btn-action-dropdown]'
     this.openInPresentationViewerBtnSelector = '.oc-files-actions-presentation-viewer-trigger'
     this.openWithBtnSelector = 'button[id^="oc-files-context-actions-open-with-toggle"]'
   }


### PR DESCRIPTION
<!--
Thanks for submitting a change to web app presentation viewer!

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the main branch which holds the next version of web app presentation viewer.

Please set the following labels:

- Assignment: assign to self
- Reviewers: pick at least one
- Labels: pick at least one
- Project: Web App Presentation Viewer (JankariTech)
-->

## Description

Opencloud has the default tiles view while owncloud have table view. Updating the context menu selector for both tiles and table view in e2e test.