### PR TITLE
[FIX] fix for text readability when dark mode enabled.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -411,7 +411,7 @@ function applyTemplateIfNeeded() {
 <style lang="scss">
 .dark-mode {
   .reveal {
-    color: var(--oc-color-text-default) !important;
+    color: var(--oc-color-text-default, var(--color-role-on-surface)) !important;
 
     h1,
     h2,
@@ -419,7 +419,7 @@ function applyTemplateIfNeeded() {
     h4,
     h5,
     h6 {
-      color: var(--oc-color-text-default) !important;
+      color: var(--oc-color-text-default, var(--color-role-on-surface));
     }
 
     code {


### PR DESCRIPTION
<!--
Thanks for submitting a change to web app presentation viewer!

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the main branch which holds the next version of web app presentation viewer.

Please set the following labels:

- Assignment: assign to self
- Reviewers: pick at least one
- Labels: pick at least one
- Project: Web App Presentation Viewer (JankariTech)
-->

## Description
When dark mode enabled some texts were hard to read. This occured only in OpenCloud as the css property `--oc-color-text-default` is undefined for OpenCloud. When dark mode was enabled the color was set to `--oc-color-text-default`.
Because of this when dark mode enabled text color remained same only for OpenCloud. So, added required css for OpenCloud.

For, the case of slide title, the color can be set by user themselves from the metadata property:
```md
---
color: "#21434f"
---
```

## Related Issue
- Fixes https://github.com/JankariTech/web-app-presentation-viewer/issues/34

## Screenshots:

|    | OpenCloud | ownCloud |
|------------|-----------|----------|
| no templating | <img width="1858" height="874" alt="Screenshot from 2025-12-05 09-26-32" src="https://github.com/user-attachments/assets/24cce78f-7f21-4433-b643-4460ec24d725" /> | <img width="1858" height="874" alt="Screenshot from 2025-12-05 09-39-22" src="https://github.com/user-attachments/assets/e01e6ca9-aedb-4664-a5f4-800c9a302cf1" /> |
| templating | <img width="1858" height="874" alt="Screenshot from 2025-12-05 09-28-47" src="https://github.com/user-attachments/assets/2b55b98c-2b3f-4190-bffc-699622bc7677" /> | <img width="1858" height="874" alt="Screenshot from 2025-12-05 09-39-14" src="https://github.com/user-attachments/assets/7c62f19d-1c28-4b7d-a0e6-19863d2e7e52" /> |
