### PR TITLE
test: add e2e tests for re-opening file in presentation viewer (#11)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,8 +102,16 @@ jobs:
       - name: install-chromium
         run: npx playwright install chromium
 
-      - name: e2e-${{ matrix.server }}
-        run: pnpm test:e2e tests/e2e/features/**/*.feature
+      - name: e2e-ocis
+        if: matrix.server == 'Ocis'
+        run: pnpm test:e2e:ocis tests/e2e/features/**/*.feature
         env:
           HEADLESS: true
-          TARGET_SERVER: ${{ matrix.server }}
+          TARGET_SERVER: ocis
+
+      - name: e2e-opencloud
+        if: matrix.server == 'Opencloud'
+        run: pnpm test:e2e:opencloud tests/e2e/features/**/*.feature
+        env:
+          HEADLESS: true
+          TARGET_SERVER: opencloud

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,21 +19,21 @@ jobs:
     strategy:
       matrix:
         server:
-          - Ocis
-          - Opencloud
+          - ocis
+          - opencloud
     runs-on: ubuntu-latest
     steps:
       - name: checkout
         uses: actions/checkout@v4
 
       - name: generate-package-json
-        run: make dependencies${{ matrix.server }}
+        run: make dependencies-${{ matrix.server }}
 
       - name: pnpm-install
         uses: pnpm/action-setup@v4
 
       - name: install
-        run: make install${{ matrix.server }}
+        run: make install-${{ matrix.server }}
 
       - name: lint
         run: pnpm lint
@@ -53,7 +53,7 @@ jobs:
         run: pnpm test:unit --coverage
 
       - name: ocis-server
-        if: matrix.server == 'Ocis'
+        if: matrix.server == 'ocis'
         run: |
           docker run --rm -d \
             -p 9200:9200 \
@@ -71,7 +71,7 @@ jobs:
             -c 'ocis init || true && ocis server'
 
       - name: opencloud-server
-        if: matrix.server == 'Opencloud'
+        if: matrix.server == 'opencloud'
         run: |
           docker run --rm -d \
             -p 9200:9200 \
@@ -102,16 +102,7 @@ jobs:
       - name: install-chromium
         run: npx playwright install chromium
 
-      - name: e2e-ocis
-        if: matrix.server == 'Ocis'
-        run: pnpm test:e2e:ocis tests/e2e/features/**/*.feature
+      - name: e2e-${{ matrix.server }}
+        run: pnpm test:e2e:${{ matrix.server }} tests/e2e/features/**/*.feature
         env:
           HEADLESS: true
-          TARGET_SERVER: ocis
-
-      - name: e2e-opencloud
-        if: matrix.server == 'Opencloud'
-        run: pnpm test:e2e:opencloud tests/e2e/features/**/*.feature
-        env:
-          HEADLESS: true
-          TARGET_SERVER: opencloud

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM owncloudci/nodejs:20 AS stage
-ARG server=Ocis
+ARG server=ocis
 
 WORKDIR /extension
 
 COPY . .
-RUN make install$server
+RUN make install-${server}
 RUN pnpm build
 
 FROM alpine:3.20

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,21 @@
-.PHONY: installOcis installOpencloud dependenciesOcis dependenciesOpencloud install clean package
+.PHONY: install-ocis install-opencloud dependencies-ocis dependencies-opencloud install clean package
 
-installOcis: dependenciesOcis install
+install-ocis: dependencies-ocis install
 
-installOpencloud: dependenciesOpencloud install
+install-opencloud: dependencies-opencloud install
 
-dependenciesOcis: clean
+dependencies-ocis: clean
 	$(MAKE) package PACKAGE_JSON=package-ocis.json
-	$(MAKE) depencenciesReplacement SOURCE=opencloud-eu DEST=ownclouders
+	$(MAKE) dependencies-replacement SOURCE=opencloud-eu DEST=ownclouders
 
-dependenciesOpencloud: clean
+dependencies-opencloud: clean
 	$(MAKE) package PACKAGE_JSON=package-opencloud.json
-	$(MAKE) depencenciesReplacement SOURCE=ownclouders DEST=opencloud-eu
+	$(MAKE) dependencies-replacement SOURCE=ownclouders DEST=opencloud-eu
 
 package:
 	jq -s '.[0] * .[1]' package-common.json $(PACKAGE_JSON) > package.json
 
-depencenciesReplacement:
+dependencies-replacement:
 	find . -type f \( -name "*.ts" -o -name "*.vue" -o -name "*.prettierrc"  \) -not \( -path "./node_modules/*" -o -path "./dist/*" \) -print0 | xargs -0 sed -i 's/${SOURCE}/${DEST}/g'
 
 clean:

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Preview:
 ## Development
 
 > [!IMPORTANT] When switching between OpenCloud and oCIS, make sure to clean the browser cache!
-> [!CAUTION] Before commiting changes run `make installOcis` and `make clean`
+> [!CAUTION] Before commiting changes run `make install-ocis` and `make clean`
 
 #### Prerequisites
 
@@ -282,12 +282,12 @@ Preview:
 
 For OpenCloud:
 ```bash
-make installOpencloud
+make install-opencloud
 ```
 
 For oCIS:
 ```bash
-make installOcis
+make install-ocis
 ```
 
 #### 2. Build the extension
@@ -331,11 +331,11 @@ Note: Scenarios tagged with `@skipOnOpenCloud` are excluded when running against
 
 For OpenCloud:
 ```bash
-docker build --build-arg server=Opencloud -t jankaritech/mdpresentation-viewer-opencloud:<version> .
+docker build --build-arg server=opencloud -t jankaritech/mdpresentation-viewer-opencloud:<version> .
 ```
 
 
-For Ocis:
+For oCIS:
 ```bash
-docker build --build-arg server=Ocis -t jankaritech/mdpresentation-viewer-ocis:<version> .
+docker build --build-arg server=ocis -t jankaritech/mdpresentation-viewer-ocis:<version> .
 ```

--- a/README.md
+++ b/README.md
@@ -317,13 +317,15 @@ server URL: [localhost:9200](https://localhost:9200)
 ### Running e2e tests:
 For oCIS:
 ```bash
-pnpm run test:e2e <path_to_feature_file>
+pnpm run test:e2e:ocis <path_to_feature_file>
 ```
 
 For OpenCloud:
 ```bash
-TARGET_SERVER=opencloud pnpm run test:e2e <path_to_feature_file>
+pnpm run test:e2e:opencloud <path_to_feature_file>
 ```
+
+Note: Scenarios tagged with `@skipOnOpenCloud` are excluded when running against OpenCloud.
 
 ## Building Docker Container
 

--- a/package-common.json
+++ b/package-common.json
@@ -11,8 +11,8 @@
     "lint": "eslint './*.{js,cjs,mjs,ts}' '{src,tests}/**/*.{js,cjs,mjs,ts,vue}' --color",
     "lint:fix": "pnpm lint --fix",
     "test:unit": "vitest",
-    "test:e2e:ocis": "NODE_TLS_REJECT_UNAUTHORIZED=0 cucumber-js",
-    "test:e2e:opencloud": "NODE_TLS_REJECT_UNAUTHORIZED=0 cucumber-js --tags \"not @skipOnOpenCloud\""
+    "test:e2e:ocis": "NODE_TLS_REJECT_UNAUTHORIZED=0 TARGET_SERVER=ocis cucumber-js",
+    "test:e2e:opencloud": "NODE_TLS_REJECT_UNAUTHORIZED=0 TARGET_SERVER=opencloud cucumber-js --tags \"not @skipOnOpenCloud\""
   },
   "dependencies": {
     "@types/reveal.js": "^4.4.8",

--- a/package-common.json
+++ b/package-common.json
@@ -11,7 +11,8 @@
     "lint": "eslint './*.{js,cjs,mjs,ts}' '{src,tests}/**/*.{js,cjs,mjs,ts,vue}' --color",
     "lint:fix": "pnpm lint --fix",
     "test:unit": "vitest",
-    "test:e2e": "NODE_TLS_REJECT_UNAUTHORIZED=0 cucumber-js"
+    "test:e2e:ocis": "NODE_TLS_REJECT_UNAUTHORIZED=0 cucumber-js",
+    "test:e2e:opencloud": "NODE_TLS_REJECT_UNAUTHORIZED=0 cucumber-js --tags \"not @skipOnOpenCloud\""
   },
   "dependencies": {
     "@types/reveal.js": "^4.4.8",

--- a/tests/e2e/config.js
+++ b/tests/e2e/config.js
@@ -10,7 +10,7 @@ const config = {
   minTimeout: parseInt(process.env.MIN_TIMEOUT) || 5,
   headless: process.env.HEADLESS === 'true',
   debug: process.env.DEBUG === 'true',
-  targetServer: process.env.TARGET_SERVER.toLowerCase() || 'ocis'
+  targetServer: (process.env.TARGET_SERVER || 'ocis').toLowerCase()
 }
 
 module.exports = config

--- a/tests/e2e/config.js
+++ b/tests/e2e/config.js
@@ -10,7 +10,7 @@ const config = {
   minTimeout: parseInt(process.env.MIN_TIMEOUT) || 5,
   headless: process.env.HEADLESS === 'true',
   debug: process.env.DEBUG === 'true',
-  targetServer: (process.env.TARGET_SERVER || 'ocis').toLowerCase()
+  targetServer: process.env.TARGET_SERVER || 'ocis'
 }
 
 module.exports = config

--- a/tests/e2e/features/presentationViewer.feature
+++ b/tests/e2e/features/presentationViewer.feature
@@ -25,11 +25,11 @@ Feature: markdown presentation viewer
 
   @skipOnOpenCloud
   Scenario: re-open markdown file in presentation viewer after opening in text editor
-  When user "admin" previews markdown file "test-markdown.md" in presentation viewer
-  Then markdown file "test-markdown.md" should be opened in the presentation viewer
-  And the content of the current slide should be "PRESENTATION VIEWER"
-  When user "admin" opens file "test-markdown.md" in text editor using sidebar panel
-  Then file "test-markdown.md" should be opened in the text editor
-  When user "admin" previews markdown file "test-markdown.md" in presentation viewer using sidebar panel
-  Then markdown file "test-markdown.md" should be opened in the presentation viewer
-  And the content of the current slide should be "PRESENTATION VIEWER"
+    When user "admin" previews markdown file "test-markdown.md" in presentation viewer
+    Then markdown file "test-markdown.md" should be opened in the presentation viewer
+    And the content of the current slide should be "PRESENTATION VIEWER"
+    When user "admin" opens file "test-markdown.md" in text editor using sidebar panel
+    Then file "test-markdown.md" should be opened in the text editor
+    When user "admin" previews markdown file "test-markdown.md" in presentation viewer using sidebar panel
+    Then markdown file "test-markdown.md" should be opened in the presentation viewer
+    And the content of the current slide should be "PRESENTATION VIEWER"

--- a/tests/e2e/features/presentationViewer.feature
+++ b/tests/e2e/features/presentationViewer.feature
@@ -9,7 +9,7 @@ Feature: markdown presentation viewer
 
 
   Scenario: preview markdown file in presentation viewer
-    When user "admin" previews a markdown file "test-markdown.md" in presentation viewer
+    When user "admin" previews markdown file "test-markdown.md" in presentation viewer
     Then markdown file "test-markdown.md" should be opened in the presentation viewer
     And the content of the current slide should be "PRESENTATION VIEWER"
     # change slide with button in UI
@@ -21,4 +21,14 @@ Feature: markdown presentation viewer
     When user "admin" navigates to the next slide using keyboard
     Then the content of the current slide should be "An extension for OpenCloud & ownCloud Infinite Scale (oCIS) that allows users to create slide presentations directly from markdown files."
     When user "admin" navigates to the previous slide using keyboard
-    Then the content of the current slide should be "PRESENTATION VIEWER" 
+    Then the content of the current slide should be "PRESENTATION VIEWER"
+
+  Scenario: re-open markdown file in presentation viewer after opening in text editor
+  When user "admin" previews markdown file "test-markdown.md" in presentation viewer
+  Then markdown file "test-markdown.md" should be opened in the presentation viewer
+  And the content of the current slide should be "PRESENTATION VIEWER"
+  When user "admin" opens file "test-markdown.md" in text editor using sidebar panel
+  Then file "test-markdown.md" should be opened in the text editor
+  When user "admin" previews markdown file "test-markdown.md" in presentation viewer using sidebar panel
+  Then markdown file "test-markdown.md" should be opened in the presentation viewer
+  And the content of the current slide should be "PRESENTATION VIEWER"

--- a/tests/e2e/features/presentationViewer.feature
+++ b/tests/e2e/features/presentationViewer.feature
@@ -23,6 +23,7 @@ Feature: markdown presentation viewer
     When user "admin" navigates to the previous slide using keyboard
     Then the content of the current slide should be "PRESENTATION VIEWER"
 
+  @skipOnOpenCloud
   Scenario: re-open markdown file in presentation viewer after opening in text editor
   When user "admin" previews markdown file "test-markdown.md" in presentation viewer
   Then markdown file "test-markdown.md" should be opened in the presentation viewer

--- a/tests/e2e/pageObjects/FilesPage.js
+++ b/tests/e2e/pageObjects/FilesPage.js
@@ -1,6 +1,5 @@
-const Ocis = require('./OcisPage')
 const config = require('../config')
-const { openActionFromSidebarPanel } = require('../utils/presentationViewer')
+const { openActionsMenuFromSidebarPanel } = require('../utils/presentationViewer')
 
 class Files {
   constructor() {
@@ -19,12 +18,12 @@ class Files {
   }
 
   async openMDFileInTextEditorUsingSidebarPanel(fileName) {
-    await openActionFromSidebarPanel()
+    await openActionsMenuFromSidebarPanel()
     await page.click(this.openInTextEditorBtnSelector)
   }
 
   async openMDFileInPresentationViewerUsingSidebarPanel(fileName) {
-    await openActionFromSidebarPanel()
+    await openActionsMenuFromSidebarPanel()
     await page.click(this.openInPresentationViewerBtnSelector)
   }
 }

--- a/tests/e2e/pageObjects/FilesPage.js
+++ b/tests/e2e/pageObjects/FilesPage.js
@@ -1,11 +1,13 @@
 const Ocis = require('./OcisPage')
 const config = require('../config')
+const { openActionFromSidebarPanel } = require('../utils/presentationViewer')
 
 class Files {
   constructor() {
     this.contextMenuBtnSelector = '[class*=-btn-action-dropdown]'
     this.openInPresentationViewerBtnSelector = '.oc-files-actions-presentation-viewer-trigger'
     this.openWithBtnSelector = 'button[id^="oc-files-context-actions-open-with-toggle"]'
+    this.openInTextEditorBtnSelector = '.oc-files-actions-text-editor-trigger'
   }
 
   async openMDFileInPresentationViewer() {
@@ -13,6 +15,16 @@ class Files {
     if (config.targetServer === 'opencloud') {
       await page.click(this.openWithBtnSelector)
     }
+    await page.click(this.openInPresentationViewerBtnSelector)
+  }
+
+  async openMDFileInTextEditorUsingSidebarPanel(fileName) {
+    await openActionFromSidebarPanel()
+    await page.click(this.openInTextEditorBtnSelector)
+  }
+
+  async openMDFileInPresentationViewerUsingSidebarPanel(fileName) {
+    await openActionFromSidebarPanel()
     await page.click(this.openInPresentationViewerBtnSelector)
   }
 }

--- a/tests/e2e/pageObjects/PresentationViewerPage.js
+++ b/tests/e2e/pageObjects/PresentationViewerPage.js
@@ -5,6 +5,10 @@ class PresentationViewer {
     this.currentSlideSelector = '#presentation-viewer-main section.present'
     this.navigateNextSlideSelector = 'button[aria-label="next slide"]'
     this.navigatePreviousSlideSelector = 'button[aria-label="previous slide"]'
+    this.textEditorContainerSelector = '#text-editor-container'
+    this.sidebarPanelSelector = '#app-sidebar'
+    this.sidebarToggleBtnSelector = '#files-toggle-sidebar'
+    this.actionsMenuSelector = '#sidebar-panel-actions-select'
   }
 
   async getCurrentSlideContent() {

--- a/tests/e2e/stepDefinitions/presentationViewerContext.js
+++ b/tests/e2e/stepDefinitions/presentationViewerContext.js
@@ -26,7 +26,7 @@ Given('user {string} has logged in', async function (user) {
 })
 
 When(
-  'user {string} previews a markdown file {string} in presentation viewer',
+  'user {string} previews markdown file {string} in presentation viewer',
   async function (user, fileName) {
     await files.openMDFileInPresentationViewer()
   }
@@ -58,4 +58,22 @@ Then('the content of the current slide should be {string}', async function (cont
   await expect(page.locator(presentationViewer.currentSlideSelector)).toBeVisible()
   const currentSlideContent = await presentationViewer.getCurrentSlideContent()
   await expect(currentSlideContent).toBe(content)
+})
+
+When(
+  'user {string} opens file {string} in text editor using sidebar panel',
+  async function (user, fileName) {
+    await files.openMDFileInTextEditorUsingSidebarPanel(fileName)
+  }
+)
+
+When(
+  'user {string} previews markdown file {string} in presentation viewer using sidebar panel',
+  async function (user, fileName) {
+    await files.openMDFileInPresentationViewerUsingSidebarPanel(fileName)
+  }
+)
+
+Then('file {string} should be opened in the text editor', async function (fileName) {
+  await expect(page.locator(presentationViewer.textEditorContainerSelector)).toBeVisible()
 })

--- a/tests/e2e/utils/presentationViewer.js
+++ b/tests/e2e/utils/presentationViewer.js
@@ -12,9 +12,9 @@ const openSidebarPanel = async () => {
   }
 }
 
-const openActionFromSidebarPanel = async () => {
+const openActionsMenuFromSidebarPanel = async () => {
   await openSidebarPanel()
   await page.click(presentationViewerPage.actionsMenuSelector)
 }
 
-module.exports = { sidebarPanelOpen, openSidebarPanel, openActionFromSidebarPanel }
+module.exports = { sidebarPanelOpen, openSidebarPanel, openActionsMenuFromSidebarPanel }

--- a/tests/e2e/utils/presentationViewer.js
+++ b/tests/e2e/utils/presentationViewer.js
@@ -1,0 +1,20 @@
+const PresentationViewer = require('../pageObjects/PresentationViewerPage')
+
+const presentationViewerPage = new PresentationViewer()
+
+const sidebarPanelOpen = async () => {
+  return await page.locator(presentationViewerPage.sidebarPanelSelector).isVisible()
+}
+
+const openSidebarPanel = async () => {
+  if (!(await sidebarPanelOpen())) {
+    await page.click(presentationViewerPage.sidebarToggleBtnSelector)
+  }
+}
+
+const openActionFromSidebarPanel = async () => {
+  await openSidebarPanel()
+  await page.click(presentationViewerPage.actionsMenuSelector)
+}
+
+module.exports = { sidebarPanelOpen, openSidebarPanel, openActionFromSidebarPanel }


### PR DESCRIPTION
<!--
Thanks for submitting a change to web app presentation viewer!

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the main branch which holds the next version of web app presentation viewer.

Please set the following labels:

- Assignment: assign to self
- Reviewers: pick at least one
- Labels: pick at least one
- Project: Web App Presentation Viewer (JankariTech)
-->

## Description
Adds end-to-end coverage for the “re-open markdown in presentation viewer after switching to the text editor” regression (issue #11), including new Cucumber steps/page-object helpers to drive the sidebar “Open with” actions and assert the text editor is shown.

Also updates the e2e test tooling to run per target server (`test:e2e:ocis` / `test:e2e:opencloud`), adjusts CI/Makefile/README accordingly, and tags the new scenario with `@skipOnOpenCloud` so it’s excluded on OpenCloud runs.

## Related Issue
- Test coverage for: #11 

## Motivation and Context

## How Has This Been Tested?
- test environment:
- Locally
- CI

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Tests only (no source changes)
- [ ] Documentation only (no source changes)
- [ ] Maintenance (e.g. dependency updates or tooling)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation updated