### PR TITLE
ci: fix revealjs-awesoMD repo url

### DIFF
--- a/package-common.json
+++ b/package-common.json
@@ -17,7 +17,7 @@
     "@types/reveal.js": "^4.4.8",
     "reveal.js": "^5.1.0",
     "reveal.js-mermaid-plugin": "^11.4.1",
-    "revealjs-awesomd": "github:opf/revealjs-awesoMD"
+    "revealjs-awesomd": "github:jankaritech/revealjs-awesoMD"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.24.5",


### PR DESCRIPTION
<!--
Thanks for submitting a change to web app presentation viewer!

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the main branch which holds the next version of web app presentation viewer.

Please set the following labels:

- Assignment: assign to self
- Reviewers: pick at least one
- Labels: pick at least one
- Project: Web App Presentation Viewer (JankariTech)
-->

## Description
This PR fixes repo url from `"revealjs-awesomd": "github:opf/revealjs-awesoMD"` to `"revealjs-awesomd": "github:jankaritech/revealjs-awesoMD"`

## Related Issue
- Fixes <issue_link>
- Part of <issue_link>

## Motivation and Context

## How Has This Been Tested?
- test environment:
- test case 1:
- test case 2:

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)
- [ ] Documentation only (no source changes)
- [ ] Maintenance (e.g. dependency updates or tooling)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation updated