### PR TITLE
fix image size in `title-content` slide

### DIFF
--- a/src/css/templates.css
+++ b/src/css/templates.css
@@ -133,8 +133,6 @@
 }
 
 .md-template .image-container .image-wrapper {
-    max-width: 100%;
-    max-height: 100px;
     padding: 5px;
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to web app presentation viewer!

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the main branch which holds the next version of web app presentation viewer.

Please set the following labels:

- Assignment: assign to self
- Reviewers: pick at least one
- Labels: pick at least one
- Project: Web App Presentation Viewer (JankariTech)
-->

## Description
This PR fixes the image size in `title-content` slide.

## Related Issue
- Fixes https://github.com/JankariTech/web-app-presentation-viewer/issues/123

## Motivation and Context

## How Has This Been Tested?
- test environment:
- test case 1:
- test case 2:

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)
- [ ] Documentation only (no source changes)
- [ ] Maintenance (e.g. dependency updates or tooling)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation updated