### PR TITLE
test: e2e test coverage for checking if content is loaded properly after opening again

### DIFF
--- a/tests/e2e/features/presentationViewer.feature
+++ b/tests/e2e/features/presentationViewer.feature
@@ -9,7 +9,12 @@ Feature: markdown presentation viewer
 
 
   Scenario: preview markdown file in presentation viewer
-    When user "admin" previews markdown file "test-markdown.md" in presentation viewer
+    When user "admin" previews markdown file "test-markdown.md" in presentation viewer using context menu
+    Then markdown file "test-markdown.md" should be opened in the presentation viewer
+    And the content of the current slide should be "PRESENTATION VIEWER"
+    # close and re-open presentation viewer
+    When user "admin" closes the presentation viewer
+    And user "admin" previews markdown file "test-markdown.md" in presentation viewer using context menu
     Then markdown file "test-markdown.md" should be opened in the presentation viewer
     And the content of the current slide should be "PRESENTATION VIEWER"
     # change slide with button in UI
@@ -25,7 +30,7 @@ Feature: markdown presentation viewer
 
   @skipOnOpenCloud
   Scenario: re-open markdown file in presentation viewer after opening in text editor
-    When user "admin" previews markdown file "test-markdown.md" in presentation viewer
+    When user "admin" previews markdown file "test-markdown.md" in presentation viewer using context menu
     Then markdown file "test-markdown.md" should be opened in the presentation viewer
     And the content of the current slide should be "PRESENTATION VIEWER"
     When user "admin" opens file "test-markdown.md" in text editor using sidebar panel

--- a/tests/e2e/pageObjects/PresentationViewerPage.js
+++ b/tests/e2e/pageObjects/PresentationViewerPage.js
@@ -9,6 +9,7 @@ class PresentationViewer {
     this.sidebarPanelSelector = '#app-sidebar'
     this.sidebarToggleBtnSelector = '#files-toggle-sidebar'
     this.actionsMenuSelector = '#sidebar-panel-actions-select'
+    this.closePresentationViewerButton = '#app-top-bar-close'
   }
 
   async getCurrentSlideContent() {
@@ -29,6 +30,10 @@ class PresentationViewer {
   async changeSlideUsingKeyboard(direction) {
     const key = direction === 'next' ? 'ArrowRight' : 'ArrowLeft'
     await page.locator('body').press(key)
+  }
+
+  async closePresentationViewer() {
+    await page.click(this.closePresentationViewerButton)
   }
 }
 

--- a/tests/e2e/stepDefinitions/presentationViewerContext.js
+++ b/tests/e2e/stepDefinitions/presentationViewerContext.js
@@ -26,7 +26,7 @@ Given('user {string} has logged in', async function (user) {
 })
 
 When(
-  'user {string} previews markdown file {string} in presentation viewer',
+  'user {string} previews markdown file {string} in presentation viewer using context menu',
   async function (user, fileName) {
     await files.openMDFileInPresentationViewer()
   }
@@ -76,4 +76,8 @@ When(
 
 Then('file {string} should be opened in the text editor', async function (fileName) {
   await expect(page.locator(presentationViewer.textEditorContainerSelector)).toBeVisible()
+})
+
+When('user {string} closes the presentation viewer', async function (user) {
+  await presentationViewer.closePresentationViewer()
 })


### PR DESCRIPTION
<!--
Thanks for submitting a change to web app presentation viewer!

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the main branch which holds the next version of web app presentation viewer.

Please set the following labels:

- Assignment: assign to self
- Reviewers: pick at least one
- Labels: pick at least one
- Project: Web App Presentation Viewer (JankariTech)
-->

## Description
This PR adds test coverage for issue: #13 
```gherkin
# close and re-open presentation viewer
When user "admin" closes the presentation viewer
And user "admin" previews markdown file "test-markdown.md" in presentation viewer using context menu
Then markdown file "test-markdown.md" should be opened in the presentation viewer
And the content of the current slide should be "PRESENTATION VIEWER"
```

## Related Issue
- Test coverage for: https://github.com/JankariTech/web-app-presentation-viewer/issues/13
- Part of: https://github.com/JankariTech/web-app-presentation-viewer/issues/16

## Motivation and Context

## How Has This Been Tested?
- test environment:
- test case 1:
- test case 2:

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)
- [ ] Documentation only (no source changes)
- [ ] Maintenance (e.g. dependency updates or tooling)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation updated