### PR TITLE
move css file to public templates directory

### DIFF
--- a/public/templates/templates.css
+++ b/public/templates/templates.css
@@ -1,32 +1,32 @@
-.md-template .slides {
+.slides {
     font-size: 28px;
 }
 
-.md-template #slideContainer > section {
+#slideContainer > section {
     justify-content: flex-start !important;
     align-items: flex-start;
 }
 
-.md-template #slideContainer h1,
-.md-template #slideContainer h2,
-.md-template #slideContainer h3,
-.md-template #slideContainer h4,
-.md-template #slideContainer h5,
-.md-template #slideContainer h6,
-.md-template #slideContainer p,
-.md-template #slideContainer img,
-.md-template #slideContainer ul,
-.md-template #slideContainer li,
-.md-template #slideContainer ol,
-.md-template #slideContainer div,
-.md-template #slideContainer footer {
+#slideContainer h1,
+#slideContainer h2,
+#slideContainer h3,
+#slideContainer h4,
+#slideContainer h5,
+#slideContainer h6,
+#slideContainer p,
+#slideContainer img,
+#slideContainer ul,
+#slideContainer li,
+#slideContainer ol,
+#slideContainer div,
+#slideContainer footer {
     margin-left: 0;
     padding: 0;
     text-transform: none;
 }
 
 
-.md-template .title {
+.title {
     top: 0;
     text-align: left;
     width: 100%;
@@ -36,30 +36,30 @@
     align-items: center;
 }
 
-.md-template .content .title h1 {
+.content .title h1 {
   text-align: center;
 }
 
-.md-template .title h1 {
+.title h1 {
     margin: 0;
 }
 
-.md-template .title p {
+.title p {
     font-size: 42px;
 }
 
-.md-template .logo {
+.logo {
     height: 80px;
     float: right;
     display: flex;
     align-items: center;
 }
 
-.md-template .logo img {
+.logo img {
     margin: 0;
 }
 
-.md-template footer {
+footer {
     width: 100%;
     height: 10%;
     font-size: 22px;
@@ -71,7 +71,7 @@
     align-items: center;
 }
 
-.md-template .content-container {
+.content-container {
     width: 100%;
     height: 90%;
     display: flex;
@@ -79,12 +79,12 @@
     align-items: flex-start;
 }
 
-.md-template .content-container ul,
-.md-template .content-container ol {
+.content-container ul,
+.content-container ol {
     padding-left: 20px !important;
 }
 
-.md-template .slides section:not(.cover) .content-container .content-wrapper {
+.slides section:not(.cover) .content-container .content-wrapper {
     min-height: 0;
     padding: 10px;
     width: 100%;
@@ -95,7 +95,7 @@
     align-items: flex-start;
 }
 
-.md-template .slides section:not(.cover) .content-container .content-wrapper .content {
+.slides section:not(.cover) .content-container .content-wrapper .content {
     max-width: 100%;
     max-height: 100%;
     width: 100%;
@@ -104,13 +104,13 @@
     justify-content: center;
 }
 
-.md-template .title-content-image .content-container .content-wrapper .content {
+.title-content-image .content-container .content-wrapper .content {
     position: relative;
     max-width: 100%;
     max-height: 100%;
 }
 
-.md-template .title-content-image .content-container .content-wrapper .content > p:has(img){
+.title-content-image .content-container .content-wrapper .content > p:has(img){
     height: 100%;
     width: 50%;
     float: right;
@@ -119,49 +119,49 @@
     right: 0;
 }
 
-.md-template .cover .content-container {
+.cover .content-container {
     justify-content: flex-start;
     align-items: center;
 }
 
-.md-template .cover .content-container .logo {
+.cover .content-container .logo {
     height: 40%;
     padding: 10px;
 }
 
-.md-template .image-container {
+.image-container {
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
 }
 
-.md-template .image-container .image-wrapper {
+.image-container .image-wrapper {
     padding: 5px;
 }
 
-.md-template .image-container .image-wrapper > img {
+.image-container .image-wrapper > img {
     height: auto;
     width: auto;
     display: block;
     margin: 0;
 }
 
-.md-template .title-content-image .content-container .content-wrapper .content {
+.title-content-image .content-container .content-wrapper .content {
     position: relative;
     width: 100%;
 }
 
 
 
-.md-template .title-content-image .content-container .content-wrapper .content > ul,
-.md-template .title-content-image .content-container .content-wrapper .content > ol,
-.md-template .title-content-image .content-container .content-wrapper .content > p,
-.md-template .title-content-image .content-container .content-wrapper .content > table {
+.title-content-image .content-container .content-wrapper .content > ul,
+.title-content-image .content-container .content-wrapper .content > ol,
+.title-content-image .content-container .content-wrapper .content > p,
+.title-content-image .content-container .content-wrapper .content > table {
     width: 50%;
 }
 
-.md-template .title-content-image .content-container .content-wrapper .content .image-container {
+.title-content-image .content-container .content-wrapper .content .image-container {
     height: 100%;
     width: 50%;
     float: right;
@@ -170,21 +170,21 @@
     right: 0;
 }
 
-.md-template .title-content-image .content-container .content-wrapper .content .image-container img {
+.title-content-image .content-container .content-wrapper .content .image-container img {
     max-width: 100%;
     height: auto;
     width: auto;
     max-height: 80vh;
 }
 
-.md-template .about-us-text {
+.about-us-text {
     width: 100%;
     color: #fff;
     text-align: center;
     padding: 20px;
 }
 
-.md-template .info-section {
+.info-section {
     display: flex;
     justify-content: space-around;
     align-items: flex-start;
@@ -193,25 +193,25 @@
     margin-top: 30px;
 }
 
-.md-template .info-box {
+.info-box {
     padding: 10px 20px;
 }
 
-.md-template .info-box h3 {
+.info-box h3 {
     margin: 10px 0;
 }
 
-.md-template .divider {
+.divider {
     width: 2px;
     background-color: #000000;
     opacity: 0.5;
     align-self: stretch;
 }
 
-.md-template .about-us .content-container .content-wrapper {
+.about-us .content-container .content-wrapper {
     justify-content: center;
 }
 
-.md-template .info-section .divider:last-child {
+.info-section .divider:last-child {
     display: none;
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -40,7 +40,6 @@ import 'reveal.js/dist/reveal.css'
 import 'reveal.js/plugin/highlight/monokai.css'
 import 'reveal.js/dist/theme/white.css'
 import './css/variables.css'
-import './css/templates.css'
 
 import { getMediaMimeTypes } from './helpers/mediaMimeTypes'
 import { id as appId } from '../public/manifest.json'
@@ -61,7 +60,7 @@ const mdTextarea = ref<HTMLTextAreaElement | null>(null)
 const mediaUrls = ref<string[]>([])
 const isReadyToShow = ref<boolean>(false)
 const presentationViewerRef = ref<HTMLElement>()
-const customCssLink = ref<HTMLStyleElement | null>(null)
+const cssLink = ref<HTMLStyleElement | null>(null)
 
 const dataSeparator = '\r?\n---\r?\n'
 const dataSeparatorVertical = '\r?\n--\r?\n'
@@ -75,7 +74,8 @@ let reveal: Reveal.Api
 const awesoMd = RevealAwesoMD()
 const baseUrl = `${window.location.origin}/assets/apps/${appId}/templates`
 awesoMd.setBaseUrl(baseUrl)
-let loadTemplate = false
+let defaultTemplate = false
+let defaultCssLoaded = false
 let customTemplate = false
 let templatePath = null
 
@@ -141,7 +141,12 @@ onMounted(async () => {
       setMarkdownContent(parsedData.join('\n'))
     })
 
-  const cssLoaded = await loadCustomCss(customTemplate)
+  const customCssLoaded = await loadCustomCss(customTemplate)
+
+  defaultTemplate = applyDefaultTemplate()
+  if (defaultTemplate) {
+    defaultCssLoaded = await loadDefaultCss()
+  }
 
   reveal = new Reveal(unref(revealContainer), {
     plugins: [awesoMd, RevealHighlight, RevealMermaid]
@@ -156,13 +161,18 @@ onMounted(async () => {
     embedded: true
   })
 
-  if (!cssLoaded) {
+  if (!customCssLoaded) {
+    isReadyToShow.value = true
+    return
+  }
+
+  if (defaultTemplate && !defaultCssLoaded) {
     isReadyToShow.value = true
     return
   }
 
   if (reveal.isReady()) {
-    applyTemplateIfNeeded()
+    setFontColor()
     addCustomSlideNumber()
     updateImageStructure()
     fitContent()
@@ -177,11 +187,11 @@ onMounted(async () => {
   isReadyToShow.value = true
 })
 onBeforeUnmount(() => {
-  presentationViewerRef.value.classList.remove('md-template')
-  if (customCssLink.value) {
-    customCssLink.value.remove()
+  if (cssLink.value) {
+    cssLink.value.remove()
   }
-  loadTemplate = false
+  defaultTemplate = false
+  defaultCssLoaded = false
   customTemplate = false
   templatePath = null
   unref(mediaUrls).forEach((url) => {
@@ -373,7 +383,7 @@ async function loadCustomCss(customTemplate: boolean): Promise<boolean> {
     style.id = 'reveal-custom-css'
     style.textContent = cssText
     document.head.appendChild(style)
-    customCssLink.value = style
+    cssLink.value = style
     return true
   } catch (err) {
     console.error('CSS fetch failed:', err)
@@ -527,7 +537,7 @@ function separateFrontmatterAndMarkdown() {
 }
 function setFontColor() {
   const frontMatter = separateFrontmatterAndMarkdown()[1]
-  const color = frontMatter.metadata.color
+  const color = frontMatter.metadata?.color
   slideContainer.value.querySelectorAll('.title p, .content .title h1').forEach((el) => {
     el.style.color = color
   })
@@ -538,17 +548,36 @@ function setFontColor() {
     el.style.color = color
   })
 }
-function applyTemplateIfNeeded() {
+function applyDefaultTemplate(): boolean {
   const [markdown, frontMatter] = separateFrontmatterAndMarkdown()
   const hasSlideMetadata = frontMatter.metadata?.slide
   const hasHeadingSlide = markdown.match(headingSlideRegex)
   const hasTemplatePath = frontMatter.metadata?.templatePath
-  loadTemplate = !!(hasSlideMetadata || hasHeadingSlide) && !hasTemplatePath
-  if (loadTemplate) {
-    presentationViewerRef.value.classList.add('md-template')
-    setFontColor()
+  return !!(hasSlideMetadata || hasHeadingSlide) && !hasTemplatePath
+}
+async function loadDefaultCss(): Promise<boolean> {
+  const cssFullPath = `${baseUrl}/templates.css`
+  const srcPath = normalizeTemplatePath(cssFullPath)
+
+  try {
+    const response = await fetch(srcPath)
+    if (!response.ok) {
+      console.error('Failed to fetch CSS file.')
+      setMarkdownContent('# Error\nFailed to fetch CSS file.')
+      return false
+    }
+    const link = document.createElement('link')
+    link.id = 'reveal-default-css'
+    link.rel = 'stylesheet'
+    link.href = srcPath
+    document.head.appendChild(link)
+    cssLink.value = link
+    return true
+  } catch (err) {
+    console.error(`Error: ${err}`)
+    setMarkdownContent(`# Error\n${err}`)
+    return false
   }
-  return loadTemplate
 }
 </script>
 

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -156,6 +156,16 @@ const createFetchMock = (markdownContent: string) => {
       })
     }
 
+    // default CSS fetch
+    if (url.includes('templates.css')) {
+      return Promise.resolve({
+        ok: true,
+        text: () => Promise.resolve('.reveal .slides { color: black; }'),
+        blob: () => Promise.resolve(new Blob([], { type: 'text/css' }))
+      })
+    }
+
+    // template HTML fetch
     if (url.includes('-template.html')) {
       const templateName = url.split('/').pop()
       const templateHtml = templateHtmlMap[templateName]
@@ -282,9 +292,17 @@ function getWrapper() {
   })
 }
 
+function normalizeSlidesHtml(html: string) {
+  return html
+    .replace(/\b no-transition\b/g, '')
+    .replace(/\bno-transition /g, '')
+    .replace(/\sclass=""/g, '')
+}
+
 // eslint-disable-next-line require-await
 describe('Template Features', async () => {
   beforeEach(() => {
+    document.getElementById('reveal-default-css')?.remove()
     global.fetch = defaultFetchMock
   })
 
@@ -340,11 +358,12 @@ logo: https://external:9200/cat.jpg
     await flushPromises()
     await vi.waitFor(
       () => {
-        expect(vm.classes('md-template')).toBe(true)
+        expect(document.getElementById('reveal-default-css')).not.toBeNull()
       },
       { timeout: 1000 }
     )
-    expect(vm.find('.reveal .slides').html()).toMatchSnapshot()
+    const slidesHtml = vm.find('.reveal .slides').html()
+    expect(normalizeSlidesHtml(slidesHtml)).toMatchSnapshot()
   })
 
   it('should render title content template', async () => {
@@ -369,11 +388,15 @@ logo: https://external:9200/cat.jpg
     await flushPromises()
     await vi.waitFor(
       () => {
-        expect(vm.classes('md-template')).toBe(true)
+        expect(document.getElementById('reveal-default-css')).not.toBeNull()
+        const slideNumber = vm.find('.reveal .slides .custom-slide-number')
+        expect(slideNumber.exists()).toBe(true)
+        expect(slideNumber.text()).toBe('1')
       },
       { timeout: 1000 }
     )
-    expect(vm.find('.reveal .slides').html()).toMatchSnapshot()
+    const slidesHtml = vm.find('.reveal .slides').html()
+    expect(normalizeSlidesHtml(slidesHtml)).toMatchSnapshot()
   })
 
   it('should render title content image template', async () => {
@@ -395,11 +418,15 @@ logo: https://external:9200/cat.jpg
     await flushPromises()
     await vi.waitFor(
       () => {
-        expect(vm.classes('md-template')).toBe(true)
+        expect(document.getElementById('reveal-default-css')).not.toBeNull()
+        const slideNumber = vm.find('.reveal .slides .custom-slide-number')
+        expect(slideNumber.exists()).toBe(true)
+        expect(slideNumber.text()).toBe('1')
       },
       { timeout: 1000 }
     )
-    expect(vm.find('.reveal .slides').html()).toMatchSnapshot()
+    const slidesHtml = vm.find('.reveal .slides').html()
+    expect(normalizeSlidesHtml(slidesHtml)).toMatchSnapshot()
   })
 
   it('should render about us template', async () => {
@@ -425,11 +452,15 @@ Some content about us.
     await flushPromises()
     await vi.waitFor(
       () => {
-        expect(vm.classes('md-template')).toBe(true)
+        expect(document.getElementById('reveal-default-css')).not.toBeNull()
+        const slideNumber = vm.find('.reveal .slides .custom-slide-number')
+        expect(slideNumber.exists()).toBe(true)
+        expect(slideNumber.text()).toBe('1')
       },
       { timeout: 1000 }
     )
-    expect(vm.find('.reveal .slides').html()).toMatchSnapshot()
+    const slidesHtml = vm.find('.reveal .slides').html()
+    expect(normalizeSlidesHtml(slidesHtml)).toMatchSnapshot()
   })
 
   it('should render title content template without the logo', async () => {
@@ -453,11 +484,82 @@ presenter: John Doe
     await flushPromises()
     await vi.waitFor(
       () => {
-        expect(vm.classes('md-template')).toBe(true)
+        expect(document.getElementById('reveal-default-css')).not.toBeNull()
+        const slideNumber = vm.find('.reveal .slides .custom-slide-number')
+        expect(slideNumber.exists()).toBe(true)
+        expect(slideNumber.text()).toBe('1')
       },
       { timeout: 1000 }
     )
-    expect(vm.find('.reveal .slides').html()).toMatchSnapshot()
+    const slidesHtml = vm.find('.reveal .slides').html()
+    expect(normalizeSlidesHtml(slidesHtml)).toMatchSnapshot()
+  })
+
+  it('should show error when default CSS fetch fails', async () => {
+    const fetchMock = vi.fn().mockImplementation((url: unknown) => {
+      if (typeof url !== 'string') {
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(''),
+          blob: () => Promise.resolve(new Blob([], { type: 'image/png' }))
+        })
+      }
+
+      if (url.includes('templates.css')) {
+        return Promise.resolve({
+          ok: false,
+          status: 404,
+          statusText: 'Not Found',
+          text: () => Promise.resolve(''),
+          blob: () => Promise.resolve(new Blob([]))
+        })
+      }
+
+      if (url.includes('slides.md')) {
+        return Promise.resolve({
+          ok: true,
+          text: () =>
+            Promise.resolve(`---
+slide: title-content
+presenter: John Doe
+logo: https://external:9200/cat.jpg
+---
+# Test Slide
+`),
+          blob: () => Promise.resolve(new Blob([], { type: 'text/markdown' }))
+        })
+      }
+
+      if (url.includes('-template.html')) {
+        const templateName = url.split('/').pop()?.split('?')[0] || ''
+        const templateHtml = templateHtmlMap[templateName] || ''
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(templateHtml),
+          blob: () => Promise.resolve(new Blob([templateHtml], { type: 'text/html' }))
+        })
+      }
+
+      return Promise.resolve({
+        ok: true,
+        text: () => Promise.resolve(''),
+        blob: () => Promise.resolve(new Blob([]))
+      })
+    })
+
+    global.fetch = fetchMock
+    const vm = getWrapper()
+    await flushPromises()
+
+    await vi.waitFor(
+      () => {
+        expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('templates.css'))
+        expect(document.getElementById('reveal-default-css')).toBeNull()
+      },
+      { timeout: 1000 }
+    )
+    const slidesHtml = vm.find('.reveal .slides').html()
+    expect(normalizeSlidesHtml(slidesHtml)).toMatchSnapshot()
   })
 })
 

--- a/tests/unit/__snapshots__/App.spec.ts.snap
+++ b/tests/unit/__snapshots__/App.spec.ts.snap
@@ -292,3 +292,12 @@ exports[`Template Features > should render title content template without the lo
   </section>
 </div>"
 `;
+
+exports[`Template Features > should show error when default CSS fetch fails 1`] = `
+"<div id="slideContainer" class="slides" style="width: 960px; height: 700px; left: 50%; top: 50%; bottom: auto; right: auto; transform: translate(-50%, -50%) scale(0.2);">
+  <section data-markdown="" data-markdown-parsed="true" style="top: 350px; display: block;" class="present">
+    <h1 id="error">Error</h1>
+    <p>Failed to fetch CSS file.</p>
+  </section>
+</div>"
+`;


### PR DESCRIPTION
<!--
Thanks for submitting a change to web app presentation viewer!

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the main branch which holds the next version of web app presentation viewer.

Please set the following labels:

- Assignment: assign to self
- Reviewers: pick at least one
- Labels: pick at least one
- Project: Web App Presentation Viewer (JankariTech)
-->

## Description
Move default css to `public/templates` directory. 
Have default templates and css file in the same directory so that users can take ideas when creating custom templates.

## Related Issue
- Closes: https://github.com/JankariTech/web-app-presentation-viewer/issues/135
