### PR TITLE
fix: prevent metadata color from styling all `h1` elements

### DIFF
--- a/public/templates/cover-template.html
+++ b/public/templates/cover-template.html
@@ -7,7 +7,9 @@
 {{/metadata.logo}}
 
 <div class="content">
+<div class="title">
 <h1>{{{ title }}}</h1>
+</div>
 
 <p>
 By: {{{ metadata.presenter }}}

--- a/src/App.vue
+++ b/src/App.vue
@@ -528,7 +528,7 @@ function separateFrontmatterAndMarkdown() {
 function setFontColor() {
   const frontMatter = separateFrontmatterAndMarkdown()[1]
   const color = frontMatter.metadata.color
-  slideContainer.value.querySelectorAll('.title p, h1').forEach((el) => {
+  slideContainer.value.querySelectorAll('.title p, .content .title h1').forEach((el) => {
     el.style.color = color
   })
   slideContainer.value.querySelectorAll('.about-us-text').forEach((el) => {

--- a/src/css/templates.css
+++ b/src/css/templates.css
@@ -36,6 +36,10 @@
     align-items: center;
 }
 
+.md-template .content .title h1 {
+  text-align: center;
+}
+
 .md-template .title h1 {
     margin: 0;
 }

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -28,7 +28,9 @@ const templateHtmlMap: Record<string, string> = {
 {{/metadata.logo}}
 
 <div class="content">
+<div class="title">
 <h1>{{{ title }}}</h1>
+</div>
 
 <p>
 By: {{{ metadata.presenter }}}

--- a/tests/unit/__snapshots__/App.spec.ts.snap
+++ b/tests/unit/__snapshots__/App.spec.ts.snap
@@ -165,7 +165,9 @@ exports[`Template Features > should render cover template 1`] = `
       </div>
 
       <div class="content">
-        <h1>Reveal Js Templates in Web App Presentation Viewer</h1>
+        <div class="title">
+          <h1>Reveal Js Templates in Web App Presentation Viewer</h1>
+        </div>
 
         <p>
           By: John Doe


### PR DESCRIPTION
<!--
Thanks for submitting a change to web app presentation viewer!

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the main branch which holds the next version of web app presentation viewer.

Please set the following labels:

- Assignment: assign to self
- Reviewers: pick at least one
- Labels: pick at least one
- Project: Web App Presentation Viewer (JankariTech)
-->

## Description
Previously, the `color` metadata was applying to all `h1` elements on the slide, not just the title. This was caused by an incorrect CSS selector `(.title p, h1)` which targeted every `h1` in the document.

Changes:

- Wrapped the `h1` in the `cover-template` inside a div to match the structure of other templates
- Updated the selector in `setFontColor()` function
- Updated the tests for cover-template

## Related Issue
- Fixes https://github.com/JankariTech/web-app-presentation-viewer/issues/127

## Motivation and Context

## How Has This Been Tested?
- Locally
- CI :robot: 

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)
- [ ] Documentation only (no source changes)
- [ ] Maintenance (e.g. dependency updates or tooling)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation updated