### PR TITLE
fix: scaling content bug

### DIFF
--- a/public/templates/templates.css
+++ b/public/templates/templates.css
@@ -210,6 +210,7 @@ footer {
     background-color: #000000;
     opacity: 0.5;
     align-self: stretch;
+    flex-shrink: 0;
 }
 
 .about-us .content-container .content-wrapper {

--- a/src/App.vue
+++ b/src/App.vue
@@ -443,6 +443,7 @@ function adjustFontSize() {
     return element.offsetHeight + marginTop + marginBottom + paddingTop + paddingBottom
   }
 
+  const contentContainer = currentSlide.querySelector('.content-container') as HTMLElement
   const contentWrapper = currentSlide.querySelector('.content-wrapper') as HTMLElement
   const content = currentSlide.querySelector('.content') as HTMLElement
 
@@ -454,54 +455,35 @@ function adjustFontSize() {
   // set minimum font size from where the image starts to get reduced as well
   // this is to prevent the font size to get too small and becomes hard to read
   const fontSizeToStartReducingImage = 12
-  let fontSize = parseFloat(getComputedStyle(content).fontSize)
 
-  while (totalHeight > contentWrapperHeight) {
+  if (totalHeight > contentWrapperHeight) {
     const scaleFactor = contentWrapperHeight / totalHeight
-    fontSize = Math.floor(scaleFactor * fontSize)
 
-    const wrapperElements = Array.from(content.children) as HTMLElement[]
-    wrapperElements.forEach((wrapperElement) => {
-      wrapperElement.style.fontSize = `${fontSize}px`
-      const style = getComputedStyle(wrapperElement)
-      const marginTop = Math.floor(parseFloat(style.marginTop) * scaleFactor)
-      const marginBottom = Math.floor(parseFloat(style.marginBottom) * scaleFactor)
-      wrapperElement.style.marginTop = `${marginTop}px`
-      wrapperElement.style.marginBottom = `${marginBottom}px`
-    })
+    if (contentContainer) {
+      contentContainer.style.fontSize = `${scaleFactor}em`
 
-    // reduce image size if font size gets smaller than minimum font size
-    const images = content.querySelectorAll(
-      '.image-container .image-wrapper img'
-    ) as NodeListOf<HTMLImageElement>
-    if (fontSize <= fontSizeToStartReducingImage && images.length > 0) {
+      const images = content.querySelectorAll(
+        '.image-container .image-wrapper img'
+      ) as NodeListOf<HTMLImageElement>
       images.forEach((image) => {
-        const currentWidth = image.offsetWidth
-        const currentHeight = image.offsetHeight
-        image.style.width = `${Math.floor(currentWidth * scaleFactor)}px`
-        image.style.height = `${Math.floor(currentHeight * scaleFactor)}px`
+        const scaledWidth = Math.floor(image.offsetWidth * scaleFactor)
+        image.style.width = `${scaledWidth}px`
+        image.style.height = 'auto'
       })
     }
-    totalHeight = getTotalHeightOfChildren(content)
   }
-
   if (currentSlide.classList.contains('about-us')) {
-    const content = currentSlide.querySelector('.content') as HTMLElement
     const infoSection = currentSlide.querySelector('.info-section') as HTMLElement
     const contentWidth = content.offsetWidth
+
     let infoSectionWidth = infoSection.scrollWidth
     while (infoSectionWidth > contentWidth) {
       const scaleFactor = contentWidth / infoSectionWidth
-      fontSize = Math.floor(scaleFactor * fontSize)
+      const currentEm = parseFloat(contentContainer.style.fontSize) || 1
+      contentContainer.style.fontSize = `${currentEm * scaleFactor}em`
 
-      const infoBoxes = infoSection.querySelectorAll('.info-box') as NodeListOf<HTMLElement>
-      infoBoxes.forEach((box) => {
-        box.style.fontSize = `${fontSize}px`
-        const style = getComputedStyle(box)
-        const padding = parseFloat(style.padding) * scaleFactor
-        box.style.padding = `${Math.max(2, Math.floor(padding))}px`
-        box.style.margin = `${Math.max(2, Math.floor(parseFloat(style.margin) * scaleFactor))}px`
-      })
+      // force reflow so scrollWidth reflects the new em value
+      infoSection.getBoundingClientRect()
       infoSectionWidth = infoSection.scrollWidth
     }
   }


### PR DESCRIPTION
<!--
Thanks for submitting a change to web app presentation viewer!

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the main branch which holds the next version of web app presentation viewer.

Please set the following labels:

- Assignment: assign to self
- Reviewers: pick at least one
- Labels: pick at least one
- Project: Web App Presentation Viewer (JankariTech)
-->

## Description
Previously, when slide content overflowed the available height, adjustFontSize stamped the same absolute px value onto every child element, collapsing the heading hierarchy and making h2, h3 and p all appear the same size.
So this PR fixes that problem of scaling. Instead of scaling individual child elements with `px`, a single `font-size` in `em` is now set on `.content-container`. Since all children inherit from the container, their relative size relationships are preserved.


## Related Issue
- Fixes https://github.com/JankariTech/web-app-presentation-viewer/issues/126

## Motivation and Context

## How Has This Been Tested?
- locally

## Screenshots (if appropriate):
Screenshots with more content:
<img width="1891" height="940" alt="example" src="https://github.com/user-attachments/assets/a948379f-50e0-4249-b336-07dc9f43c200" />

<img width="1891" height="940" alt="more-content" src="https://github.com/user-attachments/assets/e449d21b-151a-4faa-8411-ee8a1feafabc" />





## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)
- [ ] Documentation only (no source changes)
- [ ] Maintenance (e.g. dependency updates or tooling)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation updated